### PR TITLE
Convert user_id to String before validating

### DIFF
--- a/lib/stream/feed.rb
+++ b/lib/stream/feed.rb
@@ -35,7 +35,7 @@ module Stream
         end
 
         def valid_user_id(user_id)
-            !user_id[/^\w+$/].nil?
+            !user_id.to_s[/^\w+$/].nil?
         end
 
         def get(params = {})


### PR DESCRIPTION
Converting `user_id` to `String` before validating it is a handy way to avoid this error:

```
no implicit conversion of Regexp into Integer
```
