### PR TITLE
Bump timeout of API calls up from 3 seconds to 10

### DIFF
--- a/lib/stream/client.rb
+++ b/lib/stream/client.rb
@@ -62,7 +62,7 @@ module Stream
     class StreamHTTPClient
 
         include HTTParty
-        default_timeout 3
+        default_timeout 10
 
         def initialize(api_version='v1.0', location=nil)
             if location.nil?


### PR DESCRIPTION
My local Internet connection can be rather sluggish at times, so I was randomly bumping into timeouts on a fairly regular basis. I eventually discovered the default timeout of all requests to GetStream.io was only 3 seconds which seems quite tight to me. I think bumping it up to at least 10 seconds is a good idea. Ideally, this would be something that can be configured from outside the client code.

Thanks -J