### PR TITLE
Introduce Stream::Error hierarchy inheriting from StandardError

### DIFF
--- a/lib/stream/base.rb
+++ b/lib/stream/base.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'stream/client'
 require 'stream/version'
 require 'stream/signer'
-require 'stream/exceptions'
+require 'stream/errors'
 
 module Stream
     class << self

--- a/lib/stream/errors.rb
+++ b/lib/stream/errors.rb
@@ -1,0 +1,5 @@
+module Stream
+  class Error < StandardError; end
+  class StreamApiResponseException < Error; end
+  class StreamInputData < Error; end
+end

--- a/lib/stream/exceptions.rb
+++ b/lib/stream/exceptions.rb
@@ -1,8 +1,2 @@
-module Stream
-
-    class StreamApiResponseException < Exception
-    end
-
-    class StreamInputData < Exception
-    end
-end
+warn "Requiring 'stream/exceptions' is deprecated. Use 'stream/errors' instead."
+require 'stream/errors'

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+require 'stream'
+
+describe Stream::Error do
+  it { expect(Stream::Error).to be < StandardError }
+  it { expect(Stream::StreamApiResponseException).to be < Stream::Error }
+  it { expect(Stream::StreamInputData).to be < Stream::Error }
+end


### PR DESCRIPTION
The general recommendation is to rescue from `StandardError` in runtime application code. It's also generally considered bad practice to rescue from Ruby's `Exception`. Currently, when I use a common construct like the following, I can't rescue from `Stream` exception classes with `StandardError`:

```ruby
begin
  # stream-ruby api call raises StreamApiResponseException
rescue StandardError => e
  notify_error_reporting_service(e)
end

# blows up!
```

It's also nice when I can rescue from any `Stream` error with one clause if needed:

```ruby
begin
  # stream-ruby api call raises any kind of stream error
rescue Stream::Error => e
  notify_error_reporting_service(e)
end
```

This patch adds `Stream::Error` inheriting from `StandardError`, and changes the existing exceptions to inherit from `Stream::Error` - this is also recommended in the Ruby docs for `Exception`:

> It is recommended that a library should have one subclass of StandardError or RuntimeError and have specific exception types inherit from it. This allows the user to rescue a generic exception type to catch all exceptions the library may raise even if future versions of the library add new exception subclasses.

I also added a deprecation warning if helpful for users that may be depending on the `stream/exceptions` file.

http://blog.honeybadger.io/ruby-exception-vs-standarderror-whats-the-difference/
http://ruby-doc.org/core-2.2.0/Exception.html