### PR TITLE
client.rb itself should follow @rossta warning

### DIFF
--- a/lib/stream/client.rb
+++ b/lib/stream/client.rb
@@ -1,5 +1,5 @@
 require "httparty"
-require "stream/exceptions"
+require "stream/errors"
 require "stream/feed"
 require "stream/signer"
 


### PR DESCRIPTION
requiring `stream/errors` instead of `stream/exceptions`