### PR TITLE
require jwt in the Feed class, not the test

### DIFF
--- a/lib/stream/feed.rb
+++ b/lib/stream/feed.rb
@@ -1,4 +1,5 @@
 require "stream/signer"
+require "jwt"
 
 module Stream
   class Feed

--- a/spec/feed_spec.rb
+++ b/spec/feed_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require 'jwt'
 
 describe Stream::Feed do
   it "should validate feed_id" do


### PR DESCRIPTION
JWT needs to be required to use. The test worked because it required it, but the code wouldn't. Switched them.