### PR TITLE
Fix 1.9.3 support by using jwt 1.5.2

### DIFF
--- a/stream.gemspec
+++ b/stream.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.license = "Apache-2.0"
   gem.add_dependency "httparty", "~> 0"
   gem.add_dependency "http_signatures", "~> 0"
-  gem.add_dependency "jwt", ">= 0.1.5"
+  gem.add_dependency "jwt", "= 1.5.2"
   gem.add_development_dependency "rake", "~> 0"
   gem.add_development_dependency "rspec", "~> 2.10"
   gem.add_development_dependency "simplecov", "~> 0.7"


### PR DESCRIPTION
As documented here: https://github.com/jwt/ruby-jwt/issues/132