### PR TITLE
Converting to faraday

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin/
 coverage
 pkg
 ruby/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -218,3 +218,11 @@ Style/TrailingWhitespace:
 # Configuration parameters: WordRegex.
 Style/WordArray:
   Enabled: false
+
+# don't complain about code complexity
+Metrics/AbcSize:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,13 @@
  Change history
 ================
 
+2.4.5
+=====
+:release-date: 2016-12-09
+:by: Ian Douglas
+
+* Removing persistance support while we evaluate other libraries to replace httparty
+
 2.4.4
 =====
 :release-date: 2016-10-15

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,13 @@
  Change history
 ================
 
+2.5.0
+=====
+:release-date: 2016-12-19
+:by: Ian Douglas
+
+* Switched from HTTParty to Faraday to allow more fine-grained control (more to come)
+
 2.4.5
 =====
 :release-date: 2016-12-09

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org/"
 gemspec
 
 group :test do
-  gem "httparty"
+  gem "faraday"
   gem "rack"
   gem "rubocop", :require => false
   gem "simplecov"

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gemspec
 group :test do
   gem "rack"
   gem "httparty"
-  gem "persistent_httparty"
   gem "simplecov"
   gem "yard"
   gem "rubocop", :require => false

--- a/lib/stream/client.rb
+++ b/lib/stream/client.rb
@@ -2,7 +2,6 @@ require "httparty"
 require "stream/errors"
 require "stream/feed"
 require "stream/signer"
-require "persistent_httparty"
 
 module Stream
   STREAM_URL_RE = %r{https\:\/\/(?<key>\w+)\:(?<secret>\w+)@((api\.)|((?<location>[-\w]+)\.))?getstream\.io\/[\w=-\?%&]+app_id=(?<app_id>\d+)}i
@@ -100,7 +99,6 @@ module Stream
 
   class StreamHTTPClient
     include HTTParty
-    persistent_connection_adapter
 
     attr_reader :base_path
 

--- a/lib/stream/client.rb
+++ b/lib/stream/client.rb
@@ -50,10 +50,10 @@ module Stream
       @signer = Stream::Signer.new(api_secret)
 
       @client_options = {
-          :api_version => opts.fetch(:api_version, "v1.0"),
-          :location => opts.fetch(:location, nil),
-          :default_timeout => opts.fetch(:default_timeout, 3),
-          :api_key => @api_key
+        :api_version => opts.fetch(:api_version, "v1.0"),
+        :location => opts.fetch(:location, nil),
+        :default_timeout => opts.fetch(:default_timeout, 3),
+        :api_key => @api_key
       }
     end
 
@@ -79,7 +79,7 @@ module Stream
     end
 
     def get_default_params
-      {:api_key => @api_key}
+      { :api_key => @api_key }
     end
 
     def get_http_client
@@ -134,13 +134,13 @@ module Stream
       headers["Content-Type"] = "application/json"
       headers["X-Stream-Client"] = "stream-ruby-client-#{Stream::VERSION}"
 
-      params['api_key'] = @options[:api_key]
+      params["api_key"] = @options[:api_key]
       relative_url = "#{@base_path}#{relative_url}?#{URI.encode_www_form(params)}"
       response = @conn.run_request(method, relative_url, data.to_json, headers)
 
       case response[:status].to_i
-        when 200..203
-          return ::JSON.parse(response[:body])
+      when 200..203
+        return ::JSON.parse(response[:body])
       end
     end
   end
@@ -149,16 +149,16 @@ module Stream
     def call(env)
       @app.call(env).on_complete do |response|
         case response[:status].to_i
-          when 200..203
-            return response
-          when 401
-            raise StreamApiResponseException, error_message(response, "Bad feed")
-          when 403
-            raise StreamApiResponseException, error_message(response, "Bad auth/headers")
-          when 404
-            raise StreamApiResponseException, error_message(response, "url not found")
-          when 204...600
-            raise StreamApiResponseException, error_message(response, "something else")
+        when 200..203
+          return response
+        when 401
+          raise StreamApiResponseException, error_message(response, "Bad feed")
+        when 403
+          raise StreamApiResponseException, error_message(response, "Bad auth/headers")
+        when 404
+          raise StreamApiResponseException, error_message(response, "url not found")
+        when 204...600
+          raise StreamApiResponseException, error_message(response, "something else")
         end
       end
     end
@@ -170,20 +170,20 @@ module Stream
 
     private
 
-    def error_message(response, body=nil)
-      "#{response[:method].to_s.upcase} #{response[:url].to_s}: #{[response[:status].to_s + ':', body].compact.join(' ')}"
+    def error_message(response, body = nil)
+      "#{response[:method].to_s.upcase} #{response[:url]}: #{[response[:status].to_s + ':', body].compact.join(' ')}"
     end
 
     def error_body(body)
-      if not body.nil? and not body.empty? and body.kind_of?(String)
+      if !body.nil? && !body.empty? && body.is_a?(String)
         body = ::JSON.parse(body)
       end
 
       if body.nil?
         nil
-      elsif body['meta'] and body['meta']['error_message'] and not body['meta']['error_message'].empty?
+      elsif body["meta"] && body["meta"]["error_message"] && !body["meta"]["error_message"].empty?
         ": #{body['meta']['error_message']}"
-      elsif body['error_message'] and not body['error_message'].empty?
+      elsif body["error_message"] && !body["error_message"].empty?
         ": #{body['error_type']}: #{body['error_message']}"
       end
     end

--- a/lib/stream/client.rb
+++ b/lib/stream/client.rb
@@ -1,4 +1,4 @@
-require "httparty"
+require "faraday"
 require "stream/errors"
 require "stream/feed"
 require "stream/signer"
@@ -10,9 +10,7 @@ module Stream
     attr_reader :api_key
     attr_reader :api_secret
     attr_reader :app_id
-    attr_reader :api_version
-    attr_reader :location
-    attr_reader :default_timeout
+    attr_reader :client_options
 
     if RUBY_VERSION.to_f >= 2.1
       require "stream/batch"
@@ -49,13 +47,16 @@ module Stream
       @api_key = api_key
       @api_secret = api_secret
       @app_id = app_id
-      @location = opts[:location]
-      @api_version = opts.fetch(:api_version, "v1.0")
-      @default_timeout = opts.fetch(:default_timeout, 3)
       @signer = Stream::Signer.new(api_secret)
+
+      @client_options = {
+          :api_version => opts.fetch(:api_version, "v1.0"),
+          :location => opts.fetch(:location, nil),
+          :default_timeout => opts.fetch(:default_timeout, 3),
+          :api_key => @api_key
+      }
     end
 
-    #
     # Creates a feed instance
     #
     # @param [string] feed_slug the feed slug (eg. flat, aggregated...)
@@ -78,11 +79,11 @@ module Stream
     end
 
     def get_default_params
-      { :api_key => @api_key }
+      {:api_key => @api_key}
     end
 
     def get_http_client
-      @http_client ||= StreamHTTPClient.new(@api_version, @location, @default_timeout)
+      @http_client ||= StreamHTTPClient.new(@client_options)
     end
 
     def make_query_params(params)
@@ -98,48 +99,92 @@ module Stream
   end
 
   class StreamHTTPClient
-    include HTTParty
+    require "faraday"
 
+    attr_reader :conn
+    attr_reader :options
     attr_reader :base_path
 
-    def initialize(api_version = "v1.0", location = nil, default_timeout = 3)
+    def initialize(client_params)
+      @options = client_params
       location_name = "api"
-      unless location.nil?
-        location_name = "#{location}-api"
+      unless client_params[:location].nil?
+        location_name = "#{client_params[:location]}-api"
       end
-      @base_path = "/api/#{api_version}"
 
       protocol = "https"
-      if location == "qa"
+      if @options[:location] == "qa"
         protocol = "http"
       end
 
-      self.class.base_uri "#{protocol}://#{location_name}.getstream.io#{@base_path}"
-      self.class.default_timeout default_timeout
-    end
+      @base_path = "/api/#{@options[:api_version]}"
+      base_url = "#{protocol}://#{location_name}.getstream.io#{@base_path}"
 
-    def _build_error_message(response)
-      msg = "#{response['exception']} details: #{response['detail']}"
-
-      if response.key?("exception_fields")
-        response["exception_fields"].map do |field, messages|
-          msg << "\n#{field}: #{messages}"
-        end
+      @conn = Faraday.new(:url => base_url) do |faraday|
+        # faraday.request :url_encoded
+        faraday.adapter Faraday.default_adapter
+        faraday.use RaiseHttpException
+        faraday.options[:open_timeout] = @options[:default_timeout]
+        faraday.options[:timeout] = @options[:default_timeout]
       end
-
-      msg
+      @conn.path_prefix = @base_path
     end
 
     def make_http_request(method, relative_url, params = nil, data = nil, headers = nil)
       headers["Content-Type"] = "application/json"
       headers["X-Stream-Client"] = "stream-ruby-client-#{Stream::VERSION}"
-      body = data.to_json if ["post", "put"].include? method.to_s
-      response = self.class.send(method, relative_url, :headers => headers, :query => params, :body => body)
-      case response.code
-      when 200..203
-        return response
-      when 204...600
-        raise StreamApiResponseException, _build_error_message(response)
+
+      params['api_key'] = @options[:api_key]
+      relative_url = "#{@base_path}#{relative_url}?#{URI.encode_www_form(params)}"
+      response = @conn.run_request(method, relative_url, data.to_json, headers)
+
+      case response[:status].to_i
+        when 200..203
+          return ::JSON.parse(response[:body])
+      end
+    end
+  end
+
+  class RaiseHttpException < Faraday::Middleware
+    def call(env)
+      @app.call(env).on_complete do |response|
+        case response[:status].to_i
+          when 200..203
+            return response
+          when 401
+            raise StreamApiResponseException, error_message(response, "Bad feed")
+          when 403
+            raise StreamApiResponseException, error_message(response, "Bad auth/headers")
+          when 404
+            raise StreamApiResponseException, error_message(response, "url not found")
+          when 204...600
+            raise StreamApiResponseException, error_message(response, "something else")
+        end
+      end
+    end
+
+    def initialize(app)
+      super app
+      @parser = nil
+    end
+
+    private
+
+    def error_message(response, body=nil)
+      "#{response[:method].to_s.upcase} #{response[:url].to_s}: #{[response[:status].to_s + ':', body].compact.join(' ')}"
+    end
+
+    def error_body(body)
+      if not body.nil? and not body.empty? and body.kind_of?(String)
+        body = ::JSON.parse(body)
+      end
+
+      if body.nil?
+        nil
+      elsif body['meta'] and body['meta']['error_message'] and not body['meta']['error_message'].empty?
+        ": #{body['meta']['error_message']}"
+      elsif body['error_message'] and not body['error_message'].empty?
+        ": #{body['error_type']}: #{body['error_message']}"
       end
     end
   end

--- a/lib/stream/version.rb
+++ b/lib/stream/version.rb
@@ -1,3 +1,3 @@
 module Stream
-  VERSION = "2.4.5".freeze
+  VERSION = "2.5.0".freeze
 end

--- a/lib/stream/version.rb
+++ b/lib/stream/version.rb
@@ -1,3 +1,3 @@
 module Stream
-  VERSION = "2.4.4".freeze
+  VERSION = "2.4.5".freeze
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -23,8 +23,8 @@ describe Stream::Client do
     client.api_key.should eq "thierry"
     client.api_secret.should eq "pass"
     client.app_id.should eq "1"
-    client.location.should eq nil
-    client.get_http_client.class.base_uri.should eq "https://api.getstream.io/api/v1.0"
+    client.client_options[:location].should eq nil
+    client.get_http_client.conn.url_prefix.to_s.should eq "https://api.getstream.io/api/v1.0"
   end
 
   it "old heroku url" do
@@ -33,8 +33,8 @@ describe Stream::Client do
     client.api_key.should eq "thierry"
     client.api_secret.should eq "pass"
     client.app_id.should eq "1"
-    client.location.should eq nil
-    client.get_http_client.class.base_uri.should eq "https://api.getstream.io/api/v1.0"
+    client.client_options[:location].should eq nil
+    client.get_http_client.conn.url_prefix.to_s.should eq "https://api.getstream.io/api/v1.0"
   end
 
   it "heroku url with location" do
@@ -43,8 +43,8 @@ describe Stream::Client do
     client.api_key.should eq "thierry"
     client.api_secret.should eq "pass"
     client.app_id.should eq "1"
-    client.location.should eq "eu-west"
-    client.get_http_client.class.base_uri.should eq "https://eu-west-api.getstream.io/api/v1.0"
+    client.client_options[:location].should eq "eu-west"
+    client.get_http_client.conn.url_prefix.to_s.should eq "https://eu-west-api.getstream.io/api/v1.0"
   end
 
   it "heroku url with location and extra vars" do
@@ -53,8 +53,8 @@ describe Stream::Client do
     client.api_key.should eq "thierry"
     client.api_secret.should eq "pass"
     client.app_id.should eq "1"
-    client.location.should eq "eu-west"
-    client.get_http_client.class.base_uri.should eq "https://eu-west-api.getstream.io/api/v1.0"
+    client.client_options[:location].should eq "eu-west"
+    client.get_http_client.conn.url_prefix.to_s.should eq "https://eu-west-api.getstream.io/api/v1.0"
   end
 
   it "wrong heroku vars" do
@@ -71,27 +71,33 @@ describe Stream::Client do
     ENV.delete "STREAM_URL"
   end
 
+  it "should handle different api versions if specified" do
+    client = Stream::Client.new("1", "2", nil, :api_version=>"v2.345")
+    http_client = client.get_http_client
+    http_client.conn.url_prefix.to_s.should eq "https://api.getstream.io/api/v2.345"
+  end
+
   it "should handle default location as api.getstream.io" do
     client = Stream::Client.new("1", "2")
     http_client = client.get_http_client
-    http_client.class.base_uri.should eq "https://api.getstream.io/api/v1.0"
+    http_client.conn.url_prefix.to_s.should eq "https://api.getstream.io/api/v1.0"
   end
 
   it "should handle us-east location as api.getstream.io" do
     client = Stream::Client.new("1", "2", nil, :location => "us-east")
     http_client = client.get_http_client
-    http_client.class.base_uri.should eq "https://us-east-api.getstream.io/api/v1.0"
+    http_client.conn.url_prefix.to_s.should eq "https://us-east-api.getstream.io/api/v1.0"
   end
 
   it "should have 3s default timeout" do
     client = Stream::Client.new("1", "2", nil)
     http_client = client.get_http_client
-    http_client.class.default_options[:timeout].should eq 3
+    http_client.conn.options[:timeout].should eq 3
   end
 
   it "should be possible to change timeout" do
     client = Stream::Client.new("1", "2", nil, :default_timeout => 5)
     http_client = client.get_http_client
-    http_client.class.default_options[:timeout].should eq 5
+    http_client.conn.options[:timeout].should eq 5
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -72,7 +72,7 @@ describe Stream::Client do
   end
 
   it "should handle different api versions if specified" do
-    client = Stream::Client.new("1", "2", nil, :api_version=>"v2.345")
+    client = Stream::Client.new("1", "2", nil, :api_version => "v2.345")
     http_client = client.get_http_client
     http_client.conn.url_prefix.to_s.should eq "https://api.getstream.io/api/v2.345"
   end

--- a/stream.gemspec
+++ b/stream.gemspec
@@ -14,10 +14,9 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = ["README.md", "LICENSE"]
   gem.files = Dir["lib/**/*"]
   gem.license = "BSD-3-Clause"
-  gem.add_dependency "httparty", "~> 0"
+  gem.add_dependency "faraday", "~> 0.10.0"
   gem.add_dependency "http_signatures", "~> 0"
   gem.add_dependency "jwt", "= 1.5.2"
-  gem.add_dependency "persistent_httparty", "~> 0.1.2"
   gem.add_development_dependency "rake", "~> 0"
   gem.add_development_dependency "rspec", "~> 2.10"
   gem.add_development_dependency "simplecov", "~> 0.7"

--- a/upgrading.txt
+++ b/upgrading.txt
@@ -1,4 +1,8 @@
+2.5.0
+
+* error message format may not be consistent with previous versions
+
 2.0.1 Changed signature to initialise Feeds and for follow / unfollow feeds.
 
-. Stream::Feed and Stream::Client#feed signatures changed; the feed_id argument (eg. 'user:1') is not split in the feed_slug and user_id arguments ('user', '1')
-. Stream::Feed#follow and Stream::Feed#unfollow signature changed (see line above)
+* Stream::Feed and Stream::Client#feed signatures changed; the feed_id argument (eg. 'user:1') is not split in the feed_slug and user_id arguments ('user', '1')
+* Stream::Feed#follow and Stream::Feed#unfollow signature changed (see line above)


### PR DESCRIPTION
## Summary:
Switching from HTTParty to Faraday to give our users a more flexible setup environment for things like connection timeouts. We'll be adding more in the next release for things like connection pooling.
Shoutout to @rsbarbo from Turing.io for getting this started in https://github.com/GetStream/stream-ruby/pull/63

## PR - Merge Checklist:
-- Verify:
- [x] CHANGELOG updated
- [x] README updated or N/A
- [x] ALL tests have passed
- [x] Code Review is done

## Dependencies:
- [x] Faraday 0.10.0

## Risks:
None

## Rollback:
git revert