### PR TITLE
Loosen up the faraday version

### DIFF
--- a/stream.gemspec
+++ b/stream.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = ["README.md", "LICENSE"]
   gem.files = Dir["lib/**/*"]
   gem.license = "BSD-3-Clause"
-  gem.add_dependency "faraday", "~> 0.10.0"
+  gem.add_dependency "faraday", [">= 0.10.0", "< 1.0"]
   gem.add_dependency "http_signatures", "~> 0"
   gem.add_dependency "jwt", "= 1.5.2"
   gem.add_development_dependency "rake", "~> 0"


### PR DESCRIPTION
Hey,

Hoping we can relax the faraday requirement a bit in the gemspec.

Latest faraday version at this time is `0.12.1`.

Pinning the version to `~0.10` in stream-ruby is causing some conflicts in other gems we use. Specifically Apollo optics-agent (https://github.com/apollographql/optics-agent-ruby).

Not sure if there is something specific about that version that's needed for this gem.

Thanks ❤️ 💜 