### PR TITLE
Loosen jwt version requirement

### DIFF
--- a/lib/stream/version.rb
+++ b/lib/stream/version.rb
@@ -1,3 +1,3 @@
 module Stream
-  VERSION = "2.5.6".freeze
+  VERSION = "2.5.7".freeze
 end

--- a/stream.gemspec
+++ b/stream.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.license = "BSD-3-Clause"
   gem.add_dependency "faraday", [">= 0.10.0", "< 1.0"]
   gem.add_dependency "http_signatures", "~> 0"
-  gem.add_dependency "jwt", "= 1.5.2"
+  gem.add_dependency "jwt", "~> 1.5.2"
   gem.add_development_dependency "rake", "~> 0"
   gem.add_development_dependency "rspec", "~> 2.10"
   gem.add_development_dependency "simplecov", "~> 0.7"


### PR DESCRIPTION
Makes this more compatible with apps, without any backwards incompatibility. In particular the latest 1.5.x release is 1.5.6. 

(The next possible upgrade is jwt's 2.x release, so no real perceptible issues for just allowing a patch upgrade with the '~>'). 

One of the more prominent downsides is the removal of ruby 1.9.3 support in the jwt library.