### PR TITLE
new API hostname and ability to change hostname in client options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,14 @@
  Change history
 ================
 
+2.5.9
+=====
+:release-date: 2017-10-16
+:by: Ian Douglas
+
+* updating core API hostname to our new .com domain
+* added support to change the core hostname when instantiating the client (options[:api_hostame])
+
 2.5.8
 =====
 :release-date: 2017-09-21

--- a/README.md
+++ b/README.md
@@ -9,14 +9,15 @@ Note there is also a higher level [Ruby on Rails - Stream integration](https://g
 
 You can sign up for a Stream account at https://getstream.io/get_started.
 
-### Ruby Language Support
+#### Ruby version requirements and support
 
-We will support the following versions of Ruby:
-
+This API Client project requires Ruby 2.2.8 at a minimum. We will support the following versions:
 - 2.2.8
 - 2.3.1
 - 2.3.5
 - 2.4.2
+
+See the [Travis configuration](.travis.yml) for details of how it is built and tested.
 
 ### Installation
 

--- a/lib/stream.rb
+++ b/lib/stream.rb
@@ -1,1 +1,1 @@
-require "stream/base"
+require 'stream/base'

--- a/lib/stream/base.rb
+++ b/lib/stream/base.rb
@@ -1,8 +1,8 @@
-require "json"
-require "stream/client"
-require "stream/errors"
-require "stream/version"
-require "stream/signer"
+require 'json'
+require 'stream/client'
+require 'stream/errors'
+require 'stream/version'
+require 'stream/signer'
 
 module Stream
   class << self
@@ -11,7 +11,7 @@ module Stream
     end
 
     def get_feed_slug_and_id(feed_id)
-      feed_id.sub(":", "")
+      feed_id.sub(':', '')
     end
   end
 end

--- a/lib/stream/batch.rb
+++ b/lib/stream/batch.rb
@@ -19,9 +19,9 @@ module Stream
     def follow_many(follows, activity_copy_limit = nil)
       query_params = {}
       unless activity_copy_limit.nil?
-        query_params["activity_copy_limit"] = activity_copy_limit
+        query_params['activity_copy_limit'] = activity_copy_limit
       end
-      make_signed_request(:post, "/follow_many/", query_params, follows)
+      make_signed_request(:post, '/follow_many/', query_params, follows)
     end
 
     #
@@ -37,7 +37,7 @@ module Stream
         :feeds => feeds,
         :activity => activity_data
       }
-      make_signed_request(:post, "/feed/add_to_many/", {}, data)
+      make_signed_request(:post, '/feed/add_to_many/', {}, data)
     end
   end
 end

--- a/lib/stream/client.rb
+++ b/lib/stream/client.rb
@@ -4,8 +4,8 @@ require 'stream/feed'
 require 'stream/signer'
 
 module Stream
-  STREAM_URL_COM_RE = %r{https\:\/\/(?<key>\w+)\:(?<secret>\w+)@((api\.)|((?<location>[-\w]+)\.))?stream-io-api\.com\/[\w=-\?%&]+app_id=(?<app_id>\d+)}i
-  STREAM_URL_IO_RE = %r{https\:\/\/(?<key>\w+)\:(?<secret>\w+)@((api\.)|((?<location>[-\w]+)\.))?stream-io-api\.com\/[\w=-\?%&]+app_id=(?<app_id>\d+)}i
+  STREAM_URL_COM_RE = %r{https\:\/\/(?<key>\w+)\:(?<secret>\w+)@((api\.)|((?<location>[-\w]+)\.))?(?<api_hostname>stream-io-api\.com)\/[\w=-\?%&]+app_id=(?<app_id>\d+)}i
+  STREAM_URL_IO_RE = %r{https\:\/\/(?<key>\w+)\:(?<secret>\w+)@((api\.)|((?<location>[-\w]+)\.))?(?<api_hostname>getstream\.io)\/[\w=-\?%&]+app_id=(?<app_id>\d+)}i
 
   class Client
     attr_reader :api_key
@@ -39,12 +39,14 @@ module Stream
         api_secret = matches['secret']
         app_id = matches['app_id']
         opts[:location] = matches['location']
+        opts[:api_hostname] = matches['api_hostname']
       elsif ENV['STREAM_URL'] =~ Stream::STREAM_URL_IO_RE && (api_key.nil? || api_key.empty?)
         matches = Stream::STREAM_URL_IO_RE.match(ENV['STREAM_URL'])
         api_key = matches['key']
         api_secret = matches['secret']
         app_id = matches['app_id']
         opts[:location] = matches['location']
+        opts[:api_hostname] = matches['api_hostname']
       end
 
       if api_key.nil? || api_key.empty?

--- a/lib/stream/client.rb
+++ b/lib/stream/client.rb
@@ -1,10 +1,10 @@
-require "faraday"
-require "stream/errors"
-require "stream/feed"
-require "stream/signer"
+require 'faraday'
+require 'stream/errors'
+require 'stream/feed'
+require 'stream/signer'
 
 module Stream
-  STREAM_URL_RE = %r{https\:\/\/(?<key>\w+)\:(?<secret>\w+)@((api\.)|((?<location>[-\w]+)\.))?getstream\.io\/[\w=-\?%&]+app_id=(?<app_id>\d+)}i
+  STREAM_URL_RE = %r{https\:\/\/(?<key>\w+)\:(?<secret>\w+)@((api\.)|((?<location>[-\w]+)\.))?stream-io-api\.com\/[\w=-\?%&]+app_id=(?<app_id>\d+)}i
 
   class Client
     attr_reader :api_key
@@ -13,8 +13,8 @@ module Stream
     attr_reader :client_options
 
     if RUBY_VERSION.to_f >= 2.1
-      require "stream/batch"
-      require "stream/signedrequest"
+      require 'stream/batch'
+      require 'stream/signedrequest'
 
       include Stream::SignedRequest
       include Stream::Batch
@@ -31,17 +31,17 @@ module Stream
     # @example initialise the client to connect to EU-West location
     #   Stream::Client.new('my_key', 'my_secret', 'my_app_id', :location => 'us-east')
     #
-    def initialize(api_key = "", api_secret = "", app_id = nil, opts = {})
-      if ENV["STREAM_URL"] =~ Stream::STREAM_URL_RE && (api_key.nil? || api_key.empty?)
-        matches = Stream::STREAM_URL_RE.match(ENV["STREAM_URL"])
-        api_key = matches["key"]
-        api_secret = matches["secret"]
-        app_id = matches["app_id"]
-        opts[:location] = matches["location"]
+    def initialize(api_key = '', api_secret = '', app_id = nil, opts = {})
+      if ENV['STREAM_URL'] =~ Stream::STREAM_URL_RE && (api_key.nil? || api_key.empty?)
+        matches = Stream::STREAM_URL_RE.match(ENV['STREAM_URL'])
+        api_key = matches['key']
+        api_secret = matches['secret']
+        app_id = matches['app_id']
+        opts[:location] = matches['location']
       end
 
       if api_key.nil? || api_key.empty?
-        raise ArgumentError, "empty api_key parameter and missing or invalid STREAM_URL env variable"
+        raise ArgumentError, 'empty api_key parameter and missing or invalid STREAM_URL env variable'
       end
 
       @api_key = api_key
@@ -50,10 +50,10 @@ module Stream
       @signer = Stream::Signer.new(api_secret)
 
       @client_options = {
-        :api_version => opts.fetch(:api_version, "v1.0"),
-        :location => opts.fetch(:location, nil),
-        :default_timeout => opts.fetch(:default_timeout, 3),
-        :api_key => @api_key
+          :api_version => opts.fetch(:api_version, 'v1.0'),
+          :location => opts.fetch(:location, nil),
+          :default_timeout => opts.fetch(:default_timeout, 3),
+          :api_key => @api_key
       }
     end
 
@@ -74,12 +74,12 @@ module Stream
     end
 
     def update_activities(activities)
-      auth_token = Stream::Signer.create_jwt_token("activities", "*", @api_secret, "*")
-      make_request(:post, "/activities/", auth_token, {}, "activities" => activities)
+      auth_token = Stream::Signer.create_jwt_token('activities', '*', @api_secret, '*')
+      make_request(:post, '/activities/', auth_token, {}, 'activities' => activities)
     end
 
     def get_default_params
-      { :api_key => @api_key }
+      {:api_key => @api_key}
     end
 
     def get_http_client
@@ -87,19 +87,19 @@ module Stream
     end
 
     def make_query_params(params)
-      Hash[get_default_params.merge(params).sort_by { |k, v| k.to_s }]
+      Hash[get_default_params.merge(params).sort_by {|k, v| k.to_s}]
     end
 
     def make_request(method, relative_url, signature, params = {}, data = {}, headers = {})
-      headers["Authorization"] = signature
-      headers["stream-auth-type"] = "jwt"
+      headers['Authorization'] = signature
+      headers['stream-auth-type'] = 'jwt'
 
       get_http_client.make_http_request(method, relative_url, make_query_params(params), data, headers)
     end
   end
 
   class StreamHTTPClient
-    require "faraday"
+    require 'faraday'
 
     attr_reader :conn
     attr_reader :options
@@ -107,14 +107,14 @@ module Stream
 
     def initialize(client_params)
       @options = client_params
-      location_name = "api"
+      location_name = 'api'
       unless client_params[:location].nil?
         location_name = "#{client_params[:location]}-api"
       end
 
       protocol = 'https'
       port = ':443'
-      if @options[:location] == "qa" || @options[:location] == "localhost"
+      if @options[:location] == 'qa' || @options[:location] == 'localhost'
         protocol = 'http'
         port = ':80'
         if @options[:location] == 'localhost'
@@ -122,8 +122,13 @@ module Stream
         end
       end
 
+      api_hostname = 'stream-io-api.com'
+      if @options[:api_hostname]
+        api_hostname = @options[:api_hostname]
+      end
+
       @base_path = "/api/#{@options[:api_version]}"
-      base_url = "#{protocol}://#{location_name}.getstream.io#{port}#{@base_path}"
+      base_url = "#{protocol}://#{location_name}.#{api_hostname}#{port}#{@base_path}"
 
       @conn = Faraday.new(:url => base_url) do |faraday|
         # faraday.request :url_encoded
@@ -136,21 +141,21 @@ module Stream
     end
 
     def make_http_request(method, relative_url, params = nil, data = nil, headers = nil)
-      headers["Content-Type"] = "application/json"
-      headers["X-Stream-Client"] = "stream-ruby-client-#{Stream::VERSION}"
-      params["api_key"] = @options[:api_key]
+      headers['Content-Type'] = 'application/json'
+      headers['X-Stream-Client'] = "stream-ruby-client-#{Stream::VERSION}"
+      params['api_key'] = @options[:api_key]
       relative_url = "#{@base_path}#{relative_url}?#{URI.encode_www_form(params)}"
       body = data.to_json if %w(post put).include? method.to_s
       response = @conn.run_request(
-        method,
-        relative_url,
-        body,
-        headers
+          method,
+          relative_url,
+          body,
+          headers
       )
 
       case response[:status].to_i
-      when 200..203
-        return ::JSON.parse(response[:body])
+        when 200..203
+          return ::JSON.parse(response[:body])
       end
     end
   end
@@ -159,20 +164,19 @@ module Stream
     def call(env)
       @app.call(env).on_complete do |response|
         case response[:status].to_i
-        when 200..203
-          return response
-        when 401
-          raise StreamApiResponseException, error_message(response, "Bad feed")
-        when 403
-          raise StreamApiResponseException, error_message(response, "Bad auth/headers")
-        when 404
-          raise StreamApiResponseException, error_message(response, "url not found")
-        when 204...600
-          raise StreamApiResponseException, error_message(response, _build_error_message(response.body))
+          when 200..203
+            return response
+          when 401
+            raise StreamApiResponseException, error_message(response, 'Bad feed')
+          when 403
+            raise StreamApiResponseException, error_message(response, 'Bad auth/headers')
+          when 404
+            raise StreamApiResponseException, error_message(response, 'url not found')
+          when 204...600
+            raise StreamApiResponseException, error_message(response, _build_error_message(response.body))
         end
       end
     end
-
 
     def initialize(app)
       super app
@@ -184,8 +188,8 @@ module Stream
     def _build_error_message(response)
       response = JSON.parse(response)
       msg = "#{response['exception']} details: #{response['detail']}"
-      if response.key?("exception_fields")
-        response["exception_fields"].map do |field, messages|
+      if response.key?('exception_fields')
+        response['exception_fields'].map do |field, messages|
           msg << "\n#{field}: #{messages}"
         end
       end

--- a/lib/stream/exceptions.rb
+++ b/lib/stream/exceptions.rb
@@ -1,2 +1,2 @@
 warn "Requiring 'stream/exceptions' is deprecated. Use 'stream/errors' instead."
-require "stream/errors"
+require 'stream/errors'

--- a/lib/stream/feed.rb
+++ b/lib/stream/feed.rb
@@ -1,5 +1,5 @@
-require "stream/signer"
-require "jwt"
+require 'stream/signer'
+require 'jwt'
 
 module Stream
   class Feed
@@ -10,11 +10,11 @@ module Stream
 
     def initialize(client, feed_slug, user_id, token)
       unless valid_feed_slug feed_slug
-        raise StreamInputData, "feed_slug can only contain alphanumeric characters plus underscores"
+        raise StreamInputData, 'feed_slug can only contain alphanumeric characters plus underscores'
       end
 
       unless valid_user_id user_id
-        raise StreamInputData, "user_id can only contain alphanumeric characters plus underscores and dashes"
+        raise StreamInputData, 'user_id can only contain alphanumeric characters plus underscores and dashes'
       end
 
       @id = "#{feed_slug}:#{user_id}"
@@ -27,7 +27,7 @@ module Stream
     end
 
     def readonly_token
-      create_jwt_token("*", "read")
+      create_jwt_token('*', 'read')
     end
 
     def valid_feed_slug(feed_slug)
@@ -41,19 +41,19 @@ module Stream
     def get(params = {})
       uri = "/feed/#{@feed_url}/"
       if params[:mark_read] && params[:mark_read].is_a?(Array)
-        params[:mark_read] = params[:mark_read].join(",")
+        params[:mark_read] = params[:mark_read].join(',')
       end
       if params[:mark_seen] && params[:mark_seen].is_a?(Array)
-        params[:mark_seen] = params[:mark_seen].join(",")
+        params[:mark_seen] = params[:mark_seen].join(',')
       end
-      auth_token = create_jwt_token("feed", "read")
+      auth_token = create_jwt_token('feed', 'read')
 
       @client.make_request(:get, uri, auth_token, params)
     end
 
     def sign_to_field(to)
       to.map do |feed_id|
-        feed_slug, user_id = feed_id.split(":")
+        feed_slug, user_id = feed_id.split(':')
         feed = @client.feed(feed_slug, user_id)
         "#{feed.id} #{feed.token}"
       end
@@ -62,7 +62,7 @@ module Stream
     def add_activity(activity_data)
       uri = "/feed/#{@feed_url}/"
       activity_data[:to] &&= sign_to_field(activity_data[:to])
-      auth_token = create_jwt_token("feed", "write")
+      auth_token = create_jwt_token('feed', 'write')
 
       @client.make_request(:post, uri, auth_token, {}, activity_data)
     end
@@ -72,8 +72,8 @@ module Stream
       activities.each do |activity|
         activity[:to] &&= sign_to_field(activity[:to])
       end
-      data = { :activities => activities }
-      auth_token = create_jwt_token("feed", "write")
+      data = {:activities => activities}
+      auth_token = create_jwt_token('feed', 'write')
 
       @client.make_request(:post, uri, auth_token, {}, data)
     end
@@ -85,8 +85,8 @@ module Stream
     def remove_activity(activity_id, foreign_id = false)
       uri = "/feed/#{@feed_url}/#{activity_id}/"
       params = {}
-      params = { "foreign_id" => 1 } if foreign_id
-      auth_token = create_jwt_token("feed", "delete")
+      params = {foreign_id: 1} if foreign_id
+      auth_token = create_jwt_token('feed', 'delete')
 
       @client.make_request(:delete, uri, auth_token, params)
     end
@@ -96,14 +96,14 @@ module Stream
     end
 
     def update_activities(activities)
-      auth_token = create_jwt_token("activities", "*", "*")
+      auth_token = create_jwt_token('activities', '*', '*')
 
-      @client.make_request(:post, "/activities/", auth_token, {}, "activities" => activities)
+      @client.make_request(:post, '/activities/', auth_token, {}, 'activities' => activities)
     end
 
     def delete
       uri = "/feed/#{@feed_url}/"
-      auth_token = create_jwt_token("feed", "delete")
+      auth_token = create_jwt_token('feed', 'delete')
 
       @client.make_request(:delete, uri, auth_token)
     end
@@ -114,11 +114,11 @@ module Stream
       activity_copy_limit = 1000 if activity_copy_limit > 1000
 
       follow_data = {
-        target: "#{target_feed_slug}:#{target_user_id}",
-        target_token: @client.feed(target_feed_slug, target_user_id).token,
-        activity_copy_limit: activity_copy_limit
+          target: "#{target_feed_slug}:#{target_user_id}",
+          target_token: @client.feed(target_feed_slug, target_user_id).token,
+          activity_copy_limit: activity_copy_limit
       }
-      auth_token = create_jwt_token("follower", "write")
+      auth_token = create_jwt_token('follower', 'write')
 
       @client.make_request(:post, uri, auth_token, {}, follow_data)
     end
@@ -126,10 +126,10 @@ module Stream
     def followers(offset = 0, limit = 25)
       uri = "/feed/#{@feed_url}/followers/"
       params = {
-        "offset" => offset,
-        "limit" => limit
+          offset: offset,
+          limit: limit
       }
-      auth_token = create_jwt_token("follower", "read")
+      auth_token = create_jwt_token('follower', 'read')
 
       @client.make_request(:get, uri, auth_token, params)
     end
@@ -137,20 +137,20 @@ module Stream
     def following(offset = 0, limit = 25, filter = [])
       uri = "/feed/#{@feed_url}/follows/"
       params = {
-        "offset" => offset,
-        "limit" => limit,
-        "filter" => filter.join(",")
+          offset: offset,
+          limit: limit,
+          filter: filter.join(',')
       }
-      auth_token = create_jwt_token("follower", "read")
+      auth_token = create_jwt_token('follower', 'read')
 
       @client.make_request(:get, uri, auth_token, params)
     end
 
     def unfollow(target_feed_slug, target_user_id, keep_history = false)
       uri = "/feed/#{@feed_url}/follows/#{target_feed_slug}:#{target_user_id}/"
-      auth_token = create_jwt_token("follower", "delete")
+      auth_token = create_jwt_token('follower', 'delete')
       params = {}
-      params["keep_history"] = true if keep_history
+      params['keep_history'] = true if keep_history
       @client.make_request(:delete, uri, auth_token, params)
     end
 

--- a/lib/stream/signedrequest.rb
+++ b/lib/stream/signedrequest.rb
@@ -1,11 +1,12 @@
-require "http_signatures"
-require "net/http"
-require "time"
+require 'http_signatures'
+require 'net/http'
+require 'time'
 
 module Stream
   module SignedRequest
     module ClassMethods
-      def supports_signed_requests; end
+      def supports_signed_requests;
+      end
     end
 
     def self.included(klass)
@@ -15,26 +16,26 @@ module Stream
     def make_signed_request(method, relative_url, params = {}, data = {})
       query_params = make_query_params(params)
       context = HttpSignatures::Context.new(
-        keys: { @api_key => @api_secret },
-        algorithm: "hmac-sha256",
-        headers: ["(request-target)", "Date"]
+          keys: {@api_key => @api_secret},
+          algorithm: 'hmac-sha256',
+          headers: %w((request-target) Date)
       )
       method_map = {
-        :get => Net::HTTP::Get,
-        :delete => Net::HTTP::Delete,
-        :put => Net::HTTP::Put,
-        :post => Net::HTTP::Post
+          :get => Net::HTTP::Get,
+          :delete => Net::HTTP::Delete,
+          :put => Net::HTTP::Put,
+          :post => Net::HTTP::Post
       }
       request_date = Time.now.rfc822
       message = method_map[method].new(
-        "#{get_http_client.base_path}#{relative_url}?#{URI.encode_www_form(query_params)}",
-        "Date" => request_date
+          "#{get_http_client.base_path}#{relative_url}?#{URI.encode_www_form(query_params)}",
+          'Date' => request_date
       )
       context.signer.sign(message)
       headers = {
-        "Authorization" => message["Signature"],
-        "Date" => request_date,
-        "X-Api-Key" => api_key
+          Authorization: message['Signature'],
+          Date: request_date,
+          'X-Api-Key' => api_key
       }
       get_http_client.make_http_request(method, relative_url, query_params, data, headers)
     end

--- a/lib/stream/signer.rb
+++ b/lib/stream/signer.rb
@@ -1,5 +1,5 @@
-require "openssl"
-require "base64"
+require 'openssl'
+require 'base64'
 
 module Stream
   class Signer
@@ -7,11 +7,11 @@ module Stream
 
     def initialize(key)
       @key = key.to_s
-      @sha1 = OpenSSL::Digest.new("sha1")
+      @sha1 = OpenSSL::Digest.new('sha1')
     end
 
     def urlsafe_encodeb64(value)
-      value.tr("+", "-").tr("/", "_").gsub(/^=+/, "").gsub(/=+$/, "")
+      value.tr('+', '-').tr('/', '_').gsub(/^=+/, '').gsub(/=+$/, '')
     end
 
     def sign_message(message)
@@ -26,13 +26,13 @@ module Stream
 
     def self.create_jwt_token(resource, action, api_secret, feed_id = nil, user_id = nil)
       payload = {
-        "resource" => resource,
-        "action" => action
+          resource: resource,
+          action: action
       }
-      payload["feed_id"] = feed_id if feed_id
-      payload["user_id"] = user_id if user_id
+      payload['feed_id'] = feed_id if feed_id
+      payload['user_id'] = user_id if user_id
 
-      JWT.encode(payload, api_secret, "HS256")
+      JWT.encode(payload, api_secret, 'HS256')
     end
   end
 end

--- a/lib/stream/version.rb
+++ b/lib/stream/version.rb
@@ -1,3 +1,3 @@
 module Stream
-  VERSION = "2.5.8".freeze
+  VERSION = '2.5.9'.freeze
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -47,6 +47,16 @@ describe Stream::Client do
     client.get_http_client.conn.url_prefix.to_s.should eq 'https://eu-west-api.stream-io-api.com/api/v1.0'
   end
 
+  it 'heroku with getstream.io url with location' do
+    ENV['STREAM_URL'] = 'https://thierry:pass@eu-west.getstream.io/?app_id=1'
+    client = Stream::Client.new
+    client.api_key.should eq 'thierry'
+    client.api_secret.should eq 'pass'
+    client.app_id.should eq '1'
+    client.client_options[:location].should eq 'eu-west'
+    client.get_http_client.conn.url_prefix.to_s.should eq 'https://eu-west-api.getstream.io/api/v1.0'
+  end
+
   it 'heroku url with location and extra vars' do
     ENV['STREAM_URL'] = 'https://thierry:pass@eu-west.stream-io-api.com/?something_else=2&app_id=1&something_more=3'
     client = Stream::Client.new

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,102 +1,102 @@
-require "spec_helper"
-require "stream"
+require 'spec_helper'
+require 'stream'
 
 describe Stream::Client do
   after do
-    ENV.delete "STREAM_URL"
+    ENV.delete 'STREAM_URL'
   end
 
-  it "feed returns a Feed instance with id" do
-    client = Stream::Client.new("key", "secret")
-    client.api_key.should eq "key"
-    client.api_secret.should eq "secret"
-    feed = client.feed("feed", "42")
+  it 'feed returns a Feed instance with id' do
+    client = Stream::Client.new('key', 'secret')
+    client.api_key.should eq 'key'
+    client.api_secret.should eq 'secret'
+    feed = client.feed('feed', '42')
     expect(feed).to be_instance_of Stream::Feed
-    feed.user_id.should eq "42"
-    feed.slug.should eq "feed"
-    feed.id.should eq "feed:42"
+    feed.user_id.should eq '42'
+    feed.slug.should eq 'feed'
+    feed.id.should eq 'feed:42'
   end
 
-  it "on heroku we connect using environment variables" do
-    ENV["STREAM_URL"] = "https://thierry:pass@getstream.io/?app_id=1"
+  it 'on heroku we connect using environment variables' do
+    ENV['STREAM_URL'] = 'https://thierry:pass@stream-io-api.com/?app_id=1'
     client = Stream::Client.new
-    client.api_key.should eq "thierry"
-    client.api_secret.should eq "pass"
-    client.app_id.should eq "1"
+    client.api_key.should eq 'thierry'
+    client.api_secret.should eq 'pass'
+    client.app_id.should eq '1'
     client.client_options[:location].should eq nil
-    client.get_http_client.conn.url_prefix.to_s.should eq "https://api.getstream.io/api/v1.0"
+    client.get_http_client.conn.url_prefix.to_s.should eq 'https://api.stream-io-api.com/api/v1.0'
   end
 
-  it "old heroku url" do
-    ENV["STREAM_URL"] = "https://thierry:pass@api.getstream.io/?app_id=1"
+  it 'old heroku url' do
+    ENV['STREAM_URL'] = 'https://thierry:pass@api.stream-io-api.com/?app_id=1'
     client = Stream::Client.new
-    client.api_key.should eq "thierry"
-    client.api_secret.should eq "pass"
-    client.app_id.should eq "1"
+    client.api_key.should eq 'thierry'
+    client.api_secret.should eq 'pass'
+    client.app_id.should eq '1'
     client.client_options[:location].should eq nil
-    client.get_http_client.conn.url_prefix.to_s.should eq "https://api.getstream.io/api/v1.0"
+    client.get_http_client.conn.url_prefix.to_s.should eq 'https://api.stream-io-api.com/api/v1.0'
   end
 
-  it "heroku url with location" do
-    ENV["STREAM_URL"] = "https://thierry:pass@eu-west.getstream.io/?app_id=1"
+  it 'heroku url with location' do
+    ENV['STREAM_URL'] = 'https://thierry:pass@eu-west.stream-io-api.com/?app_id=1'
     client = Stream::Client.new
-    client.api_key.should eq "thierry"
-    client.api_secret.should eq "pass"
-    client.app_id.should eq "1"
-    client.client_options[:location].should eq "eu-west"
-    client.get_http_client.conn.url_prefix.to_s.should eq "https://eu-west-api.getstream.io/api/v1.0"
+    client.api_key.should eq 'thierry'
+    client.api_secret.should eq 'pass'
+    client.app_id.should eq '1'
+    client.client_options[:location].should eq 'eu-west'
+    client.get_http_client.conn.url_prefix.to_s.should eq 'https://eu-west-api.stream-io-api.com/api/v1.0'
   end
 
-  it "heroku url with location and extra vars" do
-    ENV["STREAM_URL"] = "https://thierry:pass@eu-west.getstream.io/?something_else=2&app_id=1&something_more=3"
+  it 'heroku url with location and extra vars' do
+    ENV['STREAM_URL'] = 'https://thierry:pass@eu-west.stream-io-api.com/?something_else=2&app_id=1&something_more=3'
     client = Stream::Client.new
-    client.api_key.should eq "thierry"
-    client.api_secret.should eq "pass"
-    client.app_id.should eq "1"
-    client.client_options[:location].should eq "eu-west"
-    client.get_http_client.conn.url_prefix.to_s.should eq "https://eu-west-api.getstream.io/api/v1.0"
+    client.api_key.should eq 'thierry'
+    client.api_secret.should eq 'pass'
+    client.app_id.should eq '1'
+    client.client_options[:location].should eq 'eu-west'
+    client.get_http_client.conn.url_prefix.to_s.should eq 'https://eu-west-api.stream-io-api.com/api/v1.0'
   end
 
-  it "wrong heroku vars" do
-    ENV["STREAM_URL"] = "https://thierry:pass@getstream.io/?a=1"
-    expect { Stream::Client.new }.to raise_error(ArgumentError)
+  it 'wrong heroku vars' do
+    ENV['STREAM_URL'] = 'https://thierry:pass@stream-io-api.com/?a=1'
+    expect {Stream::Client.new}.to raise_error(ArgumentError)
   end
 
-  it "but overwriting environment variables should be possible" do
-    ENV["STREAM_URL"] = "https://thierry:pass@getstream.io/?app_id=1"
-    client = Stream::Client.new("1", "2", "3")
-    client.api_key.should eq "1"
-    client.api_secret.should eq "2"
-    client.app_id.should eq "3"
-    ENV.delete "STREAM_URL"
+  it 'but overwriting environment variables should be possible' do
+    ENV['STREAM_URL'] = 'https://thierry:pass@stream-io-api.com/?app_id=1'
+    client = Stream::Client.new('1', '2', '3')
+    client.api_key.should eq '1'
+    client.api_secret.should eq '2'
+    client.app_id.should eq '3'
+    ENV.delete 'STREAM_URL'
   end
 
-  it "should handle different api versions if specified" do
-    client = Stream::Client.new("1", "2", nil, :api_version => "v2.345")
+  it 'should handle different api versions if specified' do
+    client = Stream::Client.new('1', '2', nil, :api_version => 'v2.345')
     http_client = client.get_http_client
-    http_client.conn.url_prefix.to_s.should eq "https://api.getstream.io/api/v2.345"
+    http_client.conn.url_prefix.to_s.should eq 'https://api.stream-io-api.com/api/v2.345'
   end
 
-  it "should handle default location as api.getstream.io" do
-    client = Stream::Client.new("1", "2")
+  it 'should handle default location as api.getstream.io' do
+    client = Stream::Client.new('1', '2')
     http_client = client.get_http_client
-    http_client.conn.url_prefix.to_s.should eq "https://api.getstream.io/api/v1.0"
+    http_client.conn.url_prefix.to_s.should eq 'https://api.stream-io-api.com/api/v1.0'
   end
 
-  it "should handle us-east location as api.getstream.io" do
-    client = Stream::Client.new("1", "2", nil, :location => "us-east")
+  it 'should handle us-east location as api.stream-io-api.com' do
+    client = Stream::Client.new('1', '2', nil, :location => 'us-east')
     http_client = client.get_http_client
-    http_client.conn.url_prefix.to_s.should eq "https://us-east-api.getstream.io/api/v1.0"
+    http_client.conn.url_prefix.to_s.should eq 'https://us-east-api.stream-io-api.com/api/v1.0'
   end
 
-  it "should have 3s default timeout" do
-    client = Stream::Client.new("1", "2", nil)
+  it 'should have 3s default timeout' do
+    client = Stream::Client.new('1', '2', nil)
     http_client = client.get_http_client
     http_client.conn.options[:timeout].should eq 3
   end
 
-  it "should be possible to change timeout" do
-    client = Stream::Client.new("1", "2", nil, :default_timeout => 5)
+  it 'should be possible to change timeout' do
+    client = Stream::Client.new('1', '2', nil, :default_timeout => 5)
     http_client = client.get_http_client
     http_client.conn.options[:timeout].should eq 5
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -77,10 +77,16 @@ describe Stream::Client do
     http_client.conn.url_prefix.to_s.should eq 'https://api.stream-io-api.com/api/v2.345'
   end
 
-  it 'should handle default location as api.getstream.io' do
+  it 'should handle default location as api.stream-io-api.com' do
     client = Stream::Client.new('1', '2')
     http_client = client.get_http_client
     http_client.conn.url_prefix.to_s.should eq 'https://api.stream-io-api.com/api/v1.0'
+  end
+
+  it 'should handle overriding default hostname as api.getstream.io to test SNI' do
+    client = Stream::Client.new('1', '2', nil,api_hostname: 'getstream.io')
+    http_client = client.get_http_client
+    http_client.conn.url_prefix.to_s.should eq 'https://api.getstream.io/api/v1.0'
   end
 
   it 'should handle us-east location as api.stream-io-api.com' do

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,5 +1,5 @@
-require "spec_helper"
-require "stream"
+require 'spec_helper'
+require 'stream'
 
 describe Stream::Error do
   it { expect(Stream::Error).to be < StandardError }

--- a/spec/feed_spec.rb
+++ b/spec/feed_spec.rb
@@ -1,36 +1,36 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe Stream::Feed do
-  it "should validate feed_id" do
-    feed = Stream::Feed.new(nil, "slug", "user_id", "")
+  it 'should validate feed_id' do
+    feed = Stream::Feed.new(nil, 'slug', 'user_id', '')
   end
 
-  it "should validate user_id" do
-    feed = Stream::Feed.new(nil, "slug", "user_id-1", "")
+  it 'should validate user_id' do
+    feed = Stream::Feed.new(nil, 'slug', 'user_id-1', '')
   end
 
-  it "should refuse user_id with semicolon" do
-    expect { Stream::Feed.new(nil, "slug", "user:id", "") }.to raise_error Stream::StreamInputData
+  it 'should refuse user_id with semicolon' do
+    expect {Stream::Feed.new(nil, 'slug', 'user:id', '')}.to raise_error Stream::StreamInputData
   end
 
-  it "should refuse feed_slug with dashes" do
-    expect { Stream::Feed.new(nil, "feed-slug", "user_id", "") }.to raise_error Stream::StreamInputData
+  it 'should refuse feed_slug with dashes' do
+    expect {Stream::Feed.new(nil, 'feed-slug', 'user_id', '')}.to raise_error Stream::StreamInputData
   end
 
-  it "should not refuse feed_slug with underscores" do
-    expect { Stream::Feed.new(nil, "feed_slug", "user_id", "") }.to_not raise_error # Stream::StreamInputData
+  it 'should not refuse feed_slug with underscores' do
+    expect {Stream::Feed.new(nil, 'feed_slug', 'user_id', '')}.to_not raise_error # Stream::StreamInputData
   end
 
-  describe "#readonly_token" do
-    it "should return valid JWT token" do
-      client = Stream.connect("key", "secret")
-      feed = Stream::Feed.new(client, "user", "4", "")
+  describe '#readonly_token' do
+    it 'should return valid JWT token' do
+      client = Stream.connect('key', 'secret')
+      feed = Stream::Feed.new(client, 'user', '4', '')
       payload = {
-        "resource" => "*",
-        "action" => "read",
-        "feed_id" => "user4"
+          resource: '*',
+          action: 'read',
+          feed_id: 'user4'
       }
-      token = JWT.encode(payload, "secret", "HS256")
+      token = JWT.encode(payload, 'secret', 'HS256')
 
       expect(feed.readonly_token).to eql token
     end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,208 +1,208 @@
-require "spec_helper"
-require "date"
+require 'spec_helper'
+require 'date'
 
-describe "Integration tests" do
+describe 'Integration tests' do
   before do
-    @client = Stream::Client.new(ENV["STREAM_API_KEY"], ENV["STREAM_API_SECRET"], nil, :location => 'qa')
-    # @client = Stream::Client.new(ENV["STREAM_API_KEY"], ENV["STREAM_API_SECRET"], nil, :location => ENV["STREAM_REGION"])
-    @feed42 = @client.feed("flat", "r42")
-    @feed43 = @client.feed("flat", "r43")
+    @client = Stream::Client.new(ENV['STREAM_API_KEY'], ENV['STREAM_API_SECRET'], nil, :location => 'qa')
+    # @client = Stream::Client.new(ENV['STREAM_API_KEY'], ENV['STREAM_API_SECRET'], nil, :location => ENV['STREAM_REGION'])
+    @feed42 = @client.feed('flat', 'r42')
+    @feed43 = @client.feed('flat', 'r43')
 
-    @test_activity = { :actor => 1, :verb => "tweet", :object => 1 }
+    @test_activity = {:actor => 1, :verb => 'tweet', :object => 1}
   end
 
-  context "test client" do
-    example "posting an activity" do
+  context 'test client' do
+    example 'posting an activity' do
       response = @feed42.add_activity(@test_activity)
-      response.should include("id", "actor", "verb", "object", "target", "time")
+      response.should include('id', 'actor', 'verb', 'object', 'target', 'time')
     end
 
-    example "posting many activities" do
+    example 'posting many activities' do
       activities = [
-        { :actor => "tommaso", :verb => "tweet", :object => 1 },
-        { :actor => "thierry", :verb => "tweet", :object => 1 }
+          {:actor => 'tommaso', :verb => 'tweet', :object => 1},
+          {:actor => 'thierry', :verb => 'tweet', :object => 1}
       ]
-      actors = ["tommaso", "thierry"]
+      actors = %w(tommaso thierry)
       @feed42.add_activities(activities)
-      response = @feed42.get(:limit => 5)["results"]
-      [response[0]["actor"], response[1]["actor"]].should =~ actors
+      response = @feed42.get(:limit => 5)['results']
+      [response[0]['actor'], response[1]['actor']].should =~ actors
     end
 
-    example "expose token from user feed" do
-      @feed42.token.should match(".+")
+    example 'expose token from user feed' do
+      @feed42.token.should match('.+')
     end
 
-    example "mark_seen=true should not mark read" do
-      feed = @client.feed("notification", "rb1")
-      feed.add_activity(:actor => 1, :verb => "tweet", :object => 1)
-      feed.add_activity(:actor => 2, :verb => "share", :object => 1)
-      feed.add_activity(:actor => 3, :verb => "run", :object => 1)
+    example 'mark_seen=true should not mark read' do
+      feed = @client.feed('notification', 'rb1')
+      feed.add_activity(:actor => 1, :verb => 'tweet', :object => 1)
+      feed.add_activity(:actor => 2, :verb => 'share', :object => 1)
+      feed.add_activity(:actor => 3, :verb => 'run', :object => 1)
       response = feed.get(:limit => 5)
-      response["results"][0]["is_seen"].should eq false
-      response["results"][1]["is_seen"].should eq false
-      response["results"][2]["is_seen"].should eq false
+      response['results'][0]['is_seen'].should eq false
+      response['results'][1]['is_seen'].should eq false
+      response['results'][2]['is_seen'].should eq false
       feed.get(:limit => 5, :mark_seen => true)
       response = feed.get(:limit => 5)
-      response["results"][0]["is_seen"].should eq true #####
-      response["results"][1]["is_seen"].should eq true #
-      response["results"][2]["is_seen"].should eq true
-      response["results"][0]["is_read"].should eq false
-      response["results"][1]["is_read"].should eq false
-      response["results"][2]["is_read"].should eq false
+      response['results'][0]['is_seen'].should eq true #####
+      response['results'][1]['is_seen'].should eq true #
+      response['results'][2]['is_seen'].should eq true
+      response['results'][0]['is_read'].should eq false
+      response['results'][1]['is_read'].should eq false
+      response['results'][2]['is_read'].should eq false
     end
 
-    example "mark_read=true should not mark seen" do
-      feed = @client.feed("notification", "rb1")
-      feed.add_activity(:actor => 1, :verb => "tweet", :object => 1)
-      feed.add_activity(:actor => 2, :verb => "share", :object => 1)
-      feed.add_activity(:actor => 3, :verb => "run", :object => 1)
+    example 'mark_read=true should not mark seen' do
+      feed = @client.feed('notification', 'rb1')
+      feed.add_activity(:actor => 1, :verb => 'tweet', :object => 1)
+      feed.add_activity(:actor => 2, :verb => 'share', :object => 1)
+      feed.add_activity(:actor => 3, :verb => 'run', :object => 1)
       response = feed.get(:limit => 5)
-      response["results"][0]["is_read"].should eq false
-      response["results"][1]["is_read"].should eq false
-      response["results"][2]["is_read"].should eq false
+      response['results'][0]['is_read'].should eq false
+      response['results'][1]['is_read'].should eq false
+      response['results'][2]['is_read'].should eq false
       feed.get(:limit => 5, :mark_read => true)
       response = feed.get(:limit => 5)
-      response["results"][0]["is_read"].should eq true ##
-      response["results"][1]["is_read"].should eq true ###
-      response["results"][2]["is_read"].should eq true
-      response["results"][0]["is_seen"].should eq false
-      response["results"][1]["is_seen"].should eq false
-      response["results"][2]["is_seen"].should eq false
+      response['results'][0]['is_read'].should eq true ##
+      response['results'][1]['is_read'].should eq true ###
+      response['results'][2]['is_read'].should eq true
+      response['results'][0]['is_seen'].should eq false
+      response['results'][1]['is_seen'].should eq false
+      response['results'][2]['is_seen'].should eq false
     end
 
-    example "set feed as read" do
-      feed = @client.feed("notification", "b1")
-      feed.add_activity(:actor => 1, :verb => "tweet", :object => 1)
-      feed.add_activity(:actor => 2, :verb => "share", :object => 1)
-      feed.add_activity(:actor => 3, :verb => "run", :object => 1)
+    example 'set feed as read' do
+      feed = @client.feed('notification', 'b1')
+      feed.add_activity(:actor => 1, :verb => 'tweet', :object => 1)
+      feed.add_activity(:actor => 2, :verb => 'share', :object => 1)
+      feed.add_activity(:actor => 3, :verb => 'run', :object => 1)
       response = feed.get(:limit => 5)
-      response["results"][0]["is_read"].should eq false
-      response["results"][1]["is_read"].should eq false
-      response["results"][2]["is_read"].should eq false #
+      response['results'][0]['is_read'].should eq false
+      response['results'][1]['is_read'].should eq false
+      response['results'][2]['is_read'].should eq false #
       feed.get(:limit => 5, :mark_read => true)
       response = feed.get(:limit => 5)
-      response["results"][0]["is_read"].should eq true #
-      response["results"][1]["is_read"].should eq true
-      response["results"][2]["is_read"].should eq true
+      response['results'][0]['is_read'].should eq true #
+      response['results'][1]['is_read'].should eq true
+      response['results'][2]['is_read'].should eq true
     end
 
-    example "set activities as read" do
-      feed = @client.feed("notification", "rb2")
-      feed.add_activity(:actor => 1, :verb => "tweet", :object => 1)
-      feed.add_activity(:actor => 2, :verb => "share", :object => 1)
-      feed.add_activity(:actor => 3, :verb => "run", :object => 1)
+    example 'set activities as read' do
+      feed = @client.feed('notification', 'rb2')
+      feed.add_activity(:actor => 1, :verb => 'tweet', :object => 1)
+      feed.add_activity(:actor => 2, :verb => 'share', :object => 1)
+      feed.add_activity(:actor => 3, :verb => 'run', :object => 1)
       response = feed.get(:limit => 2)
-      ids = response["results"].collect { |a| a["id"] }
+      ids = response['results'].collect {|a| a['id']}
       feed.get(:limit => 5, :mark_read => ids)
       response = feed.get(:limit => 5)
-      response["results"][0]["is_read"].should eq true #
-      response["results"][1]["is_read"].should eq true
-      response["results"][2]["is_read"].should eq false #
+      response['results'][0]['is_read'].should eq true #
+      response['results'][1]['is_read'].should eq true
+      response['results'][2]['is_read'].should eq false #
     end
 
-    example "set feed as seen" do
-      feed = @client.feed("notification", "rb3")
-      feed.add_activity(:actor => 1, :verb => "tweet", :object => 1)
-      feed.add_activity(:actor => 2, :verb => "share", :object => 1)
-      feed.add_activity(:actor => 3, :verb => "run", :object => 1)
+    example 'set feed as seen' do
+      feed = @client.feed('notification', 'rb3')
+      feed.add_activity(:actor => 1, :verb => 'tweet', :object => 1)
+      feed.add_activity(:actor => 2, :verb => 'share', :object => 1)
+      feed.add_activity(:actor => 3, :verb => 'run', :object => 1)
       response = feed.get(:limit => 5)
-      response["results"][0]["is_seen"].should eq false
-      response["results"][1]["is_seen"].should eq false
-      response["results"][2]["is_seen"].should eq false ##
+      response['results'][0]['is_seen'].should eq false
+      response['results'][1]['is_seen'].should eq false
+      response['results'][2]['is_seen'].should eq false ##
       feed.get(:limit => 5, :mark_seen => true)
       response = feed.get(:limit => 5)
-      response["results"][0]["is_seen"].should eq true
-      response["results"][1]["is_seen"].should eq true
-      response["results"][2]["is_seen"].should eq true
+      response['results'][0]['is_seen'].should eq true
+      response['results'][1]['is_seen'].should eq true
+      response['results'][2]['is_seen'].should eq true
     end
 
-    example "set activities as seen" do
-      feed = @client.feed("notification", "rb4")
-      feed.add_activity(:actor => 1, :verb => "tweet", :object => 1)
-      feed.add_activity(:actor => 2, :verb => "share", :object => 1)
-      feed.add_activity(:actor => 3, :verb => "run", :object => 1)
+    example 'set activities as seen' do
+      feed = @client.feed('notification', 'rb4')
+      feed.add_activity(:actor => 1, :verb => 'tweet', :object => 1)
+      feed.add_activity(:actor => 2, :verb => 'share', :object => 1)
+      feed.add_activity(:actor => 3, :verb => 'run', :object => 1)
       response = feed.get(:limit => 2)
-      ids = response["results"].collect { |a| a["id"] }
+      ids = response['results'].collect {|a| a['id']}
       feed.get(:limit => 5, :mark_seen => ids)
       response = feed.get(:limit => 5)
-      response["results"][0]["is_seen"].should eq true
-      response["results"][1]["is_seen"].should eq true
-      response["results"][2]["is_seen"].should eq false
+      response['results'][0]['is_seen'].should eq true
+      response['results'][1]['is_seen'].should eq true
+      response['results'][2]['is_seen'].should eq false
     end
 
-    example "posting an activity with datetime object" do
-      feed = @client.feed("flat", "time42")
-      activity = { :actor => 1, :verb => "tweet", :object => 1, :time => DateTime.now }
+    example 'posting an activity with datetime object' do
+      feed = @client.feed('flat', 'time42')
+      activity = {:actor => 1, :verb => 'tweet', :object => 1, :time => DateTime.now}
       response = feed.add_activity(activity)
-      response.should include("id", "actor", "verb", "object", "target", "time")
+      response.should include('id', 'actor', 'verb', 'object', 'target', 'time')
     end
 
-    example "localised datetimes should be returned in UTC correctly" do
-      feed = @client.feed("flat", "time43")
+    example 'localised datetimes should be returned in UTC correctly' do
+      feed = @client.feed('flat', 'time43')
       now = DateTime.now.new_offset(5)
-      activity = { :actor => 1, :verb => "tweet", :object => 1, :time => now }
+      activity = {:actor => 1, :verb => 'tweet', :object => 1, :time => now}
       response = feed.add_activity(activity)
-      response.should include("id", "actor", "verb", "object", "target", "time")
+      response.should include('id', 'actor', 'verb', 'object', 'target', 'time')
       response = feed.get(:limit => 5)
-      DateTime.iso8601(response["results"][0]["time"]).should be_within(1).of(now.new_offset(0))
+      DateTime.iso8601(response['results'][0]['time']).should be_within(1).of(now.new_offset(0))
     end
 
-    example "posting a custom field as a hash" do
-      hash_value = { "a" => 42 }
-      activity = { :actor => 1, :verb => "tweet", :object => 1, :hash_data => hash_value }
+    example 'posting a custom field as a hash' do
+      hash_value = {'a' => 42}
+      activity = {:actor => 1, :verb => 'tweet', :object => 1, :hash_data => hash_value}
       response = @feed42.add_activity(activity)
-      response.should include("id", "actor", "verb", "object", "target", "hash_data")
-      results = @feed42.get(:limit => 1)["results"]
-      results[0]["hash_data"].should eq hash_value
+      response.should include('id', 'actor', 'verb', 'object', 'target', 'hash_data')
+      results = @feed42.get(:limit => 1)['results']
+      results[0]['hash_data'].should eq hash_value
     end
 
-    example "posting a custom field as a list" do
+    example 'posting a custom field as a list' do
       list_value = [1, 2, 3]
-      activity = { :actor => 1, :verb => "tweet", :object => 1, :hash_data => list_value }
+      activity = {:actor => 1, :verb => 'tweet', :object => 1, :hash_data => list_value}
       response = @feed42.add_activity(activity)
-      response.should include("id", "actor", "verb", "object", "target", "hash_data")
-      results = @feed42.get(:limit => 1)["results"]
-      results[0]["hash_data"].should eq list_value
+      response.should include('id', 'actor', 'verb', 'object', 'target', 'hash_data')
+      results = @feed42.get(:limit => 1)['results']
+      results[0]['hash_data'].should eq list_value
     end
 
-    example "posting and get one activity" do
+    example 'posting and get one activity' do
       response = @feed42.add_activity(@test_activity)
-      results = @feed42.get(:limit => 1)["results"]
-      results[0]["id"].should eq response["id"]
+      results = @feed42.get(:limit => 1)['results']
+      results[0]['id'].should eq response['id']
     end
 
-    example "removing an activity" do
-      feed = @client.feed("flat", "removing_an_activity")
+    example 'removing an activity' do
+      feed = @client.feed('flat', 'removing_an_activity')
       response = feed.add_activity(@test_activity)
-      results = feed.get(:limit => 1)["results"]
-      results[0]["id"].should eq response["id"]
-      feed.remove_activity(response["id"])
-      results = feed.get(:limit => 1)["results"]
-      results[0]["id"].should_not eq response["id"] if results.count > 0
+      results = feed.get(:limit => 1)['results']
+      results[0]['id'].should eq response['id']
+      feed.remove_activity(response['id'])
+      results = feed.get(:limit => 1)['results']
+      results[0]['id'].should_not eq response['id'] if results.count > 0
     end
 
-    example "removing an activity by foreign_id" do
-      activity = { :actor => 1, :verb => "tweet", :object => 1, :foreign_id => "ruby:42" }
+    example 'removing an activity by foreign_id' do
+      activity = {:actor => 1, :verb => 'tweet', :object => 1, :foreign_id => 'ruby:42'}
       @feed42.add_activity(activity)
-      activity = { :actor => 1, :verb => "tweet", :object => 1, :foreign_id => "ruby:43" }
+      activity = {:actor => 1, :verb => 'tweet', :object => 1, :foreign_id => 'ruby:43'}
       @feed42.add_activity(activity)
-      @feed42.remove_activity("ruby:43", foreign_id = true)
-      results = @feed42.get(:limit => 2)["results"]
-      results[0]["foreign_id"].should eq "ruby:42"
+      @feed42.remove_activity('ruby:43', foreign_id = true)
+      results = @feed42.get(:limit => 2)['results']
+      results[0]['foreign_id'].should eq 'ruby:42'
     end
 
-    example "delete a feed" do
+    example 'delete a feed' do
       response = @feed42.add_activity(@test_activity)
-      response.should include("id", "actor", "verb", "object", "target", "time")
+      response.should include('id', 'actor', 'verb', 'object', 'target', 'time')
       @feed42.delete
       response = @feed42.get
-      response["results"].length.should eq 0
+      response['results'].length.should eq 0
     end
 
     context 'following a feed' do
       context 'should copy an activity' do
         example 'when no copy limit is mentioned' do
-          feed1 = @client.feed('flat', "1")
+          feed1 = @client.feed('flat', '1')
           feed2 = @client.feed('flat', 'activity_copy_not_given')
           feed1.add_activity(@test_activity)
           feed2.follow('flat', '1')
@@ -233,105 +233,105 @@ describe "Integration tests" do
       end
     end
 
-    example "retrieve feed with no followers" do
-      lonely = @client.feed("flat", "lkjasdlkjalskdjlkjasd")
+    example 'retrieve feed with no followers' do
+      lonely = @client.feed('flat', 'lkjasdlkjalskdjlkjasd')
       response = lonely.followers
-      response["results"].should eq []
+      response['results'].should eq []
     end
 
-    example "retrieve feed followers with limit and offset" do
-      @client.feed("flat", "r43").follow("flat", "r123")
-      @client.feed("flat", "r44").follow("flat", "r123")
-      response = @client.feed("flat", "r123").followers
-      response["results"][0]["feed_id"].should eq "flat:r44"
-      response["results"][0]["target_id"].should eq "flat:r123"
-      response["results"][1]["feed_id"].should eq "flat:r43"
-      response["results"][1]["target_id"].should eq "flat:r123"
+    example 'retrieve feed followers with limit and offset' do
+      @client.feed('flat', 'r43').follow('flat', 'r123')
+      @client.feed('flat', 'r44').follow('flat', 'r123')
+      response = @client.feed('flat', 'r123').followers
+      response['results'][0]['feed_id'].should eq 'flat:r44'
+      response['results'][0]['target_id'].should eq 'flat:r123'
+      response['results'][1]['feed_id'].should eq 'flat:r43'
+      response['results'][1]['target_id'].should eq 'flat:r123'
     end
 
-    example "retrieve feed with no followings" do
-      asocial = @client.feed("flat", "rasocial")
+    example 'retrieve feed with no followings' do
+      asocial = @client.feed('flat', 'rasocial')
       response = asocial.following
-      response["results"].should eq []
+      response['results'].should eq []
     end
 
-    example "retrieve feed followings with limit and offset" do
-      social = @client.feed("flat", "r2social")
-      social.follow("flat", "r43")
-      social.follow("flat", "r44")
+    example 'retrieve feed followings with limit and offset' do
+      social = @client.feed('flat', 'r2social')
+      social.follow('flat', 'r43')
+      social.follow('flat', 'r44')
       response = social.following(1, 1)
-      response["results"][0]["feed_id"].should eq "flat:r2social"
-      response["results"][0]["target_id"].should eq "flat:r43"
+      response['results'][0]['feed_id'].should eq 'flat:r2social'
+      response['results'][0]['target_id'].should eq 'flat:r43'
     end
 
-    example "i dont follow" do
-      social = @client.feed("flat", "rsocial1")
-      response = social.following(0, 10, filter = ["flat:asocial"])
-      response["results"].should eq []
+    example 'i dont follow' do
+      social = @client.feed('flat', 'rsocial1')
+      response = social.following(0, 10, filter = ['flat:asocial'])
+      response['results'].should eq []
     end
 
-    example "do i follow" do
-      social = @client.feed("flat", "rsocial2")
-      social.follow("flat", "r43")
-      social.follow("flat", "r244")
-      response = social.following(0, 10, filter = ["flat:r244"])
-      response["results"][0]["feed_id"].should eq "flat:rsocial2"
-      response["results"][0]["target_id"].should eq "flat:r244"
-      response = social.following(1, 10, filter = ["flat:r244"])
-      response["results"].should eq []
+    example 'do i follow' do
+      social = @client.feed('flat', 'rsocial2')
+      social.follow('flat', 'r43')
+      social.follow('flat', 'r244')
+      response = social.following(0, 10, filter = ['flat:r244'])
+      response['results'][0]['feed_id'].should eq 'flat:rsocial2'
+      response['results'][0]['target_id'].should eq 'flat:r244'
+      response = social.following(1, 10, filter = ['flat:r244'])
+      response['results'].should eq []
     end
 
-    example "unfollowing a feed" do
-      @feed42.follow("flat", "43")
-      @feed42.unfollow("flat", "43")
+    example 'unfollowing a feed' do
+      @feed42.follow('flat', '43')
+      @feed42.unfollow('flat', '43')
     end
 
-    example "unfollowing a feed but keep history" do
-      follower = @client.feed("flat", "keeper")
-      follower.follow("flat", "keepit")
-      keepit = @client.feed("flat", "keepit")
+    example 'unfollowing a feed but keep history' do
+      follower = @client.feed('flat', 'keeper')
+      follower.follow('flat', 'keepit')
+      keepit = @client.feed('flat', 'keepit')
       response = keepit.add_activity(@test_activity)
-      follower.unfollow("flat", "keepit", :keep_history => true)
-      follower.get["results"][0]["id"].should eq response["id"]
+      follower.unfollow('flat', 'keepit', :keep_history => true)
+      follower.get['results'][0]['id'].should eq response['id']
     end
 
-    example "posting activity using to" do
-      recipient = "flat", "toruby11"
+    example 'posting activity using to' do
+      recipient = 'flat', 'toruby11'
       activity = {
-        :actor => "tommaso", :verb => "tweet", :object => 1, :to => [recipient.join(":")]
+          :actor => 'tommaso', :verb => 'tweet', :object => 1, :to => [recipient.join(':')]
       }
       @feed42.add_activity(activity)
       target_feed = @client.feed(*recipient)
-      response = target_feed.get(:limit => 5)["results"]
-      response[0]["actor"].should eq "tommaso"
+      response = target_feed.get(:limit => 5)['results']
+      response[0]['actor'].should eq 'tommaso'
     end
 
-    example "posting many activities using to" do
-      recipient = "flat", "toruby1"
+    example 'posting many activities using to' do
+      recipient = 'flat', 'toruby1'
       activities = [
-        { :actor => "tommaso", :verb => "tweet", :object => 1, :to => [recipient.join(":")] },
-        { :actor => "thierry", :verb => "tweet", :object => 1, :to => [recipient.join(":")] }
+          {:actor => 'tommaso', :verb => 'tweet', :object => 1, :to => [recipient.join(':')]},
+          {:actor => 'thierry', :verb => 'tweet', :object => 1, :to => [recipient.join(':')]}
       ]
-      actors = ["tommaso", "thierry"]
+      actors = %w(tommaso thierry)
       @feed42.add_activities(activities)
       target_feed = @client.feed(*recipient)
-      response = target_feed.get(:limit => 5)["results"]
-      [response[0]["actor"], response[1]["actor"]].should =~ actors
+      response = target_feed.get(:limit => 5)['results']
+      [response[0]['actor'], response[1]['actor']].should =~ actors
     end
 
-    example "read from a feed" do
+    example 'read from a feed' do
       @feed42.get
       @feed42.get(:limit => 5)
       @feed42.get(:offset => 4, :limit => 5)
     end
 
-    example "add incomplete activity" do
+    example 'add incomplete activity' do
       expect do
         @feed42.add_activity({})
       end.to raise_error Stream::StreamApiResponseException
     end
 
-    if Stream::Client.respond_to?("supports_signed_requests")
+    if Stream::Client.respond_to?('supports_signed_requests')
       # it "should be able to send signed requests" do
       #   @client.make_signed_request(:get, "/test/auth/digest/")
       # end
@@ -340,66 +340,66 @@ describe "Integration tests" do
       #   @client.make_signed_request(:post, "/test/auth/digest/", {}, :var => [1, 2, "3"])
       # end
 
-      it "should be able to follow many feeds in one request" do
+      it 'should be able to follow many feeds in one request' do
         follows = [
-          { :source => "flat:1", :target => "user:1" },
-          { :source => "flat:1", :target => "user:3" }
+            {:source => 'flat:1', :target => 'user:1'},
+            {:source => 'flat:1', :target => 'user:3'}
         ]
         @client.follow_many(follows)
       end
 
-      it "should return an appropriate error if following many fails" do
+      it 'should return an appropriate error if following many fails' do
         follows = [
-          { :source => "badfeed:1", :target => "alsobad:1" },
-          { :source => "extrabadfeed:1", :target => "reallybad:3" }
+            {:source => 'badfeed:1', :target => 'alsobad:1'},
+            {:source => 'extrabadfeed:1', :target => 'reallybad:3'}
         ]
         expect do
           @client.follow_many(follows, 5000)
         end.to raise_error(
                    Stream::StreamApiResponseException,
-                   "POST http://qa-api.getstream.io/api/v1.0/follow_many/?activity_copy_limit=5000&api_key=ncr5uednmnnz: 400: InputException details: Errors for fields 'activity_copy_limit'\nactivity_copy_limit: [\"Ensure this value is less than or equal to 300.\"]"
+                   "POST http://qa-api.stream-io-api.com/api/v1.0/follow_many/?activity_copy_limit=5000&api_key=ncr5uednmnnz: 400: InputException details: Errors for fields 'activity_copy_limit'\nactivity_copy_limit: [\"Ensure this value is less than or equal to 300.\"]"
                )
       end
 
-      it "should be able to add one activity to many feeds in one request" do
-        feeds = ["flat:1", "flat:2", "flat:3", "flat:4"]
-        activity_data = { :actor => "tommaso", :verb => "tweet", :object => 1 }
-        response = @client.add_to_many(activity_data, feeds)
+      it 'should be able to add one activity to many feeds in one request' do
+        feeds = %w(flat:1 flat:2 flat:3 flat:4)
+        activity_data = {:actor => 'tommaso', :verb => 'tweet', :object => 1}
+        @client.add_to_many(activity_data, feeds)
       end
     end
 
-    example "updating many feed activities" do
+    example 'updating many feed activities' do
       activities = []
       (0..10).each do |i|
         activities << {
-          "actor" => "user:1",
-          "verb" => "do",
-          "object" => "object:#{i}",
-          "foreign_id" => "object:#{i}",
-          "time" => DateTime.now
+            actor: 'user:1',
+            verb: 'do',
+            object: "object:#{i}",
+            foreign_id: "object:#{i}",
+            time: DateTime.now
         }
         sleep 1
       end
-      created_activities = @feed43.add_activities(activities)["activities"]
+      created_activities = @feed43.add_activities(activities)['activities']
       activities = Marshal.load(Marshal.dump(created_activities))
 
       sleep 3
 
       activities.each do |activity|
-        activity.delete("id")
-        activity["popularity"] = 100
+        activity.delete('id')
+        activity['popularity'] = 100
       end
 
       @client.update_activities(activities)
 
       sleep 2
 
-      updated_activities = @feed43.get(limit: activities.length)["results"].reverse
+      updated_activities = @feed43.get(limit: activities.length)['results'].reverse
       expect(updated_activities.count).to eql created_activities.count
       updated_activities.each_with_index do |activity, idx|
-        expect(created_activities[idx]["foreign_id"]).to eql activity["foreign_id"]
-        expect(created_activities[idx]["id"]).to eql activity["id"]
-        expect(activity["popularity"]).to eql 100
+        expect(created_activities[idx]['foreign_id']).to eql activity['foreign_id']
+        expect(created_activities[idx]['id']).to eql activity['id']
+        expect(activity['popularity']).to eql 100
       end
     end
   end

--- a/spec/signer_spec.rb
+++ b/spec/signer_spec.rb
@@ -1,8 +1,8 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe Stream::Signer do
-  it "tests a token" do
-    signer = Stream::Signer.new("123")
-    signer.sign(1, 23).should eq "U_B-Ll24uKGqPayl1Nm-iJMXjIQ"
+  it 'tests a token' do
+    signer = Stream::Signer.new('123')
+    signer.sign(1, 23).should eq 'U_B-Ll24uKGqPayl1Nm-iJMXjIQ'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require "simplecov"
-require "stream"
+require 'simplecov'
+require 'stream'
 
 SimpleCov.minimum_coverage 90
 SimpleCov.start

--- a/spec/stream_spec.rb
+++ b/spec/stream_spec.rb
@@ -1,8 +1,8 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe Stream do
-  it "connects returns a client instance" do
-    client = Stream.connect("key", "secret")
+  it 'connects returns a client instance' do
+    client = Stream.connect('key', 'secret')
     expect(client).to be_instance_of Stream::Client
   end
 end


### PR DESCRIPTION
Users will connect to our new .com domain in case another .io TLD problem happens. Users can also set `options[:api_hostname]` when instantiating the API client to set their own domain name.