### PR TITLE
moved faraday.adapter setting later in the setup to avoid middleware warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ env:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - rvm: '2.4.2'
+#  allow_failures:
+#    - rvm: '2.4.2'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,13 @@
  Change history
 ================
 
+2.5.10
+=====
+:release-date: 2017-12-01
+:by: Ian Douglas
+
+* Minor modification for Faraday middleware warning
+
 2.5.9
 =====
 :release-date: 2017-10-16

--- a/lib/stream/client.rb
+++ b/lib/stream/client.rb
@@ -142,10 +142,12 @@ module Stream
 
       @conn = Faraday.new(:url => base_url) do |faraday|
         # faraday.request :url_encoded
-        faraday.adapter Faraday.default_adapter
         faraday.use RaiseHttpException
         faraday.options[:open_timeout] = @options[:default_timeout]
         faraday.options[:timeout] = @options[:default_timeout]
+
+        # do this last
+        faraday.adapter Faraday.default_adapter
       end
       @conn.path_prefix = @base_path
     end

--- a/lib/stream/version.rb
+++ b/lib/stream/version.rb
@@ -1,3 +1,3 @@
 module Stream
-  VERSION = '2.5.9'.freeze
+  VERSION = '2.5.10'.freeze
 end

--- a/stream.gemspec
+++ b/stream.gemspec
@@ -1,23 +1,23 @@
-$LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
-require "stream/version"
+$LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
+require 'stream/version'
 
 Gem::Specification.new do |gem|
-  gem.name = "stream-ruby"
-  gem.description = "Ruby client for getstream.io service"
+  gem.name = 'stream-ruby'
+  gem.description = 'Ruby client for getstream.io service'
   gem.version = Stream::VERSION
   gem.platform = Gem::Platform::RUBY
-  gem.summary = "A gem that provides a client interface for getstream.io"
-  gem.email = "support@getstream.io"
-  gem.homepage = "http://github.com/GetStream/stream-ruby"
-  gem.authors = ["Tommaso Barbugli", "Ian Douglas"]
+  gem.summary = 'A gem that provides a client interface for getstream.io'
+  gem.email = 'support@getstream.io'
+  gem.homepage = 'http://github.com/GetStream/stream-ruby'
+  gem.authors = ['Tommaso Barbugli', 'Ian Douglas']
   gem.has_rdoc = true
-  gem.extra_rdoc_files = ["README.md", "LICENSE"]
-  gem.files = Dir["lib/**/*"]
-  gem.license = "BSD-3-Clause"
-  gem.add_dependency "faraday", [">= 0.10.0", "< 1.0"]
-  gem.add_dependency "http_signatures", "~> 0"
-  gem.add_dependency "jwt", "~> 1.5.2"
-  gem.add_development_dependency "rake", "~> 0"
-  gem.add_development_dependency "rspec", "~> 2.10"
-  gem.add_development_dependency "simplecov", "~> 0.7"
+  gem.extra_rdoc_files = %w(README.md LICENSE)
+  gem.files = Dir['lib/**/*']
+  gem.license = 'BSD-3-Clause'
+  gem.add_dependency 'faraday', ['>= 0.10.0', '< 1.0']
+  gem.add_dependency 'http_signatures', '~> 0'
+  gem.add_dependency 'jwt', '~> 1.5.2'
+  gem.add_development_dependency 'rake', '~> 0'
+  gem.add_development_dependency 'rspec', '~> 2.10'
+  gem.add_development_dependency 'simplecov', '~> 0.7'
 end


### PR DESCRIPTION
Also updated the gemspec for single quotes and removed 2.4.2 as a failure-allowed choice on Travis