### PR TITLE
Use a clearer param format for foreign id retrieval

### DIFF
--- a/lib/stream/activities.rb
+++ b/lib/stream/activities.rb
@@ -4,23 +4,40 @@ module Stream
     #
     # Get activities directly, via ID or Foreign ID + timestamp
     #
-    # @param [Hash<:ids, :foreign_ids, :timestamps>] params the request params (ids or foreign_ids + timestamps)
+    # @param [Hash<:ids, :foreign_id_times>] params the request params (ids or list of <:foreign_id, :time> objects)
     #
     # @return the found activities, if any.
     #
     # @example
     #
     #
-    # @client.get_activities({
-    #   ids: [ '4b39fda2-d6e2-42c9-9abf-5301ef071b12', '89b910d3-1ef5-44f8-914e-e7735d79e817' ]
-    # })
+    # @client.get_activities(
+    #   ids: [
+    #     '4b39fda2-d6e2-42c9-9abf-5301ef071b12',
+    #     '89b910d3-1ef5-44f8-914e-e7735d79e817'
+    #   ]
+    # )
     #
-    # @client.get_activities({
-    #   foreign_ids: [ 'post:1000',                  'like:2000' ]
-    #   timestamps:  [ '2016-11-10T13:20:00.000000', '2018-01-07T09:15:59.123456' ]
-    # })
+    # @client.get_activities(
+    #   foreign_id_times: [
+    #     { foreign_id: 'post:1000', time: '2016-11-10T13:20:00.000000' },
+    #     { foreign_id: 'like:2000', time: '2018-01-07T09:15:59.123456' }
+    #   ]
+    # )
     #
     def get_activities(params = {})
+      if params[:foreign_id_times]
+        foreign_ids = []
+        timestamps = []
+        params[:foreign_id_times].each{|e|
+          foreign_ids << e[:foreign_id]
+          timestamps << e[:time]
+        }
+        params = {
+          foreign_ids: foreign_ids,
+          timestamps: timestamps,
+        }
+      end
       signature = Stream::Signer.create_jwt_token('activities', '*', @api_secret, '*')
       make_request(:get, '/activities/', signature, params)
     end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -526,8 +526,9 @@ describe 'Integration tests' do
 
         # get by foreign_id/timestamp
         by_foreign_id = @client.get_activities(
-          foreign_ids: [ activity["foreign_id"] ],
-          timestamps:  [ activity["time"] ],
+          foreign_id_times: [
+            { foreign_id: activity["foreign_id"], time: activity["time"] }
+          ]
         )
         by_foreign_id.should include('duration', 'results')
         by_foreign_id['results'].count.should be 1


### PR DESCRIPTION
Support retrieving single activities by foreign ID as

```ruby
client.get_activities(
	foreign_id_times: [
		{ foreign_id: 'post:1000', time: '2016-11-10T13:20:00.000000' },
		{ foreign_id: 'like:2000', time: '2018-01-07T09:15:59.123456' },
		...
	]
)
```