### PR TITLE
Shallow-copy the activity data during addition

### DIFF
--- a/lib/stream/feed.rb
+++ b/lib/stream/feed.rb
@@ -61,10 +61,11 @@ module Stream
 
     def add_activity(activity_data)
       uri = "/feed/#{@feed_url}/"
-      activity_data[:to] &&= sign_to_field(activity_data[:to])
+      data = activity_data.clone
+      data[:to] &&= sign_to_field(data[:to])
       auth_token = create_jwt_token('feed', 'write')
 
-      @client.make_request(:post, uri, auth_token, {}, activity_data)
+      @client.make_request(:post, uri, auth_token, {}, data)
     end
 
     def add_activities(activities)


### PR DESCRIPTION
When signing `to` targets during activity addition the original activity data is actually changed, leading to validation failed if trying to add the same activity again, plus more potential side effects.
This PR shallow-copies the data during signing/addition, without altering the original activity object.