### PR TITLE
fix function call

### DIFF
--- a/lib/stream/feed.rb
+++ b/lib/stream/feed.rb
@@ -68,7 +68,7 @@ module Stream
     end
 
     def remove(activity_id, foreign_id: false)
-      remove_activity(activity_id, foreign_id)
+      remove_activity(activity_id, foreign_id: foreign_id)
     end
 
     def remove_activity(activity_id, foreign_id: false)


### PR DESCRIPTION
Fix `remove_activity` function call. 
Current methods expect to receive a hash as last parameters. This PR fixes that