### PR TITLE
fix(rubocop): ENV.fetch('xy') instead of ENV['xy'] per rubocop

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 
 ## 📝 About Stream
 
+> 💡 This is a library for the **Feeds** product. The Chat SDKs can be found [here](https://getstream.io/chat/docs/).
+
 You can sign up for a Stream account at our [Get Started](https://getstream.io/get_started/) page.
 
 You can use this library to access Feeds API endpoints server-side.

--- a/lib/stream/client.rb
+++ b/lib/stream/client.rb
@@ -38,7 +38,7 @@ module Stream
     #
     def initialize(api_key = '', api_secret = '', app_id = nil, opts = {})
       if api_key.nil? || api_key.empty?
-        env_url = ENV['STREAM_URL']
+        env_url = ENV.fetch('STREAM_URL', nil)
         if env_url =~ Stream::STREAM_URL_COM_RE
           re = Stream::STREAM_URL_COM_RE
         elsif env_url =~ Stream::STREAM_URL_IO_RE
@@ -46,7 +46,7 @@ module Stream
         end
         raise ArgumentError, 'empty api_key parameter and missing or invalid STREAM_URL env variable' unless re
 
-        matches = re.match(ENV['STREAM_URL'])
+        matches = re.match(ENV.fetch('STREAM_URL', nil))
         api_key = matches['key']
         api_secret = matches['secret']
         app_id = matches['app_id']

--- a/lib/stream/url.rb
+++ b/lib/stream/url.rb
@@ -12,8 +12,8 @@ module Stream
       location = make_location(options[:location])
       location ||= 'api'
       api_version = options[:api_version] || 'v1.0'
-      if ENV['STREAM_URL']
-        uri = URI.parse(ENV['STREAM_URL'])
+      if ENV.fetch('STREAM_URL', nil)
+        uri = URI.parse(ENV.fetch('STREAM_URL'))
         scheme = uri.scheme
         host = uri.host
         port = uri.port
@@ -22,7 +22,7 @@ module Stream
         host = options[:api_hostname]
         port = 443
       end
-      unless ENV['STREAM_URL'] =~ /localhost/
+      unless ENV.fetch('STREAM_URL', nil) =~ /localhost/
         host_parts = host.split('.')
         host = host_parts.slice(1..-1).join('.') if host_parts.length == 3
         host = "#{location}.#{host}" if location

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -3,7 +3,7 @@ require 'stream'
 
 describe Stream::Client do
   before do
-    @env_url = ENV['STREAM_URL']
+    @env_url = ENV.fetch('STREAM_URL', nil)
   end
 
   after do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -8,7 +8,7 @@ end
 
 describe 'Integration tests' do
   before(:all) do
-    @client = Stream::Client.new(ENV['STREAM_API_KEY'], ENV['STREAM_API_SECRET'], nil, location: ENV['STREAM_REGION'], default_timeout: 10)
+    @client = Stream::Client.new(ENV.fetch('STREAM_API_KEY'), ENV.fetch('STREAM_API_SECRET'), nil, location: ENV.fetch('STREAM_REGION', nil), default_timeout: 10)
     @feed42 = @client.feed('flat', generate_uniq_feed_name)
     @feed43 = @client.feed('flat', generate_uniq_feed_name)
 


### PR DESCRIPTION
Plus fix rubocop error