### PR TITLE
feat: specific exception classes for errors

### DIFF
--- a/lib/stream/errors.rb
+++ b/lib/stream/errors.rb
@@ -3,5 +3,39 @@ module Stream
 
   class StreamApiResponseException < Error; end
 
+  class StreamApiResponseApiKeyException < StreamApiResponseException; end
+
+  class StreamApiResponseSignatureException < StreamApiResponseException; end
+
+  class StreamApiResponseInputException < StreamApiResponseException; end
+
+  class StreamApiResponseCustomFieldException < StreamApiResponseException; end
+
+  class StreamApiResponseFeedConfigException < StreamApiResponseException; end
+
+  class StreamApiResponseSiteSuspendedException < StreamApiResponseException; end
+
+  class StreamApiResponseInvalidPaginationException < StreamApiResponseException; end
+
+  class StreamApiResponseRateLimitReached < StreamApiResponseException; end
+
+  class StreamApiResponseMissingRankingException < StreamApiResponseFeedConfigException; end
+
+  class StreamApiResponseMissingUserException < StreamApiResponseException; end
+
+  class StreamApiResponseRankingException < StreamApiResponseFeedConfigException; end
+
+  class StreamApiResponseOldStorageBackendException < StreamApiResponseException; end
+
+  class StreamApiResponseJinjaRuntimeException < StreamApiResponseException; end
+
+  class StreamApiResponseBestPracticeException < StreamApiResponseException; end
+
+  class StreamApiResponseDoesNotExistException < StreamApiResponseException; end
+
+  class StreamApiResponseNotAllowedException < StreamApiResponseException; end
+
+  class StreamApiResponseConflictException < StreamApiResponseException; end
+
   class StreamInputData < Error; end
 end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -4,5 +4,23 @@ require 'stream'
 describe Stream::Error do
   it { expect(Stream::Error).to be < StandardError }
   it { expect(Stream::StreamApiResponseException).to be < Stream::Error }
+  it { expect(Stream::StreamApiResponseDoesNotExistException).to be < Stream::StreamApiResponseException }
+  it { expect(Stream::StreamApiResponseApiKeyException).to be < Stream::StreamApiResponseException }
+  it { expect(Stream::StreamApiResponseSignatureException).to be < Stream::StreamApiResponseException }
+  it { expect(Stream::StreamApiResponseInputException).to be < Stream::StreamApiResponseException }
+  it { expect(Stream::StreamApiResponseCustomFieldException).to be < Stream::StreamApiResponseException }
+  it { expect(Stream::StreamApiResponseFeedConfigException).to be < Stream::StreamApiResponseException }
+  it { expect(Stream::StreamApiResponseSiteSuspendedException).to be < Stream::StreamApiResponseException }
+  it { expect(Stream::StreamApiResponseInvalidPaginationException).to be < Stream::StreamApiResponseException }
+  it { expect(Stream::StreamApiResponseRateLimitReached).to be < Stream::StreamApiResponseException }
+  it { expect(Stream::StreamApiResponseMissingUserException).to be < Stream::StreamApiResponseException }
+  it { expect(Stream::StreamApiResponseMissingRankingException).to be < Stream::StreamApiResponseFeedConfigException }
+  it { expect(Stream::StreamApiResponseRankingException).to be < Stream::StreamApiResponseFeedConfigException }
+  it { expect(Stream::StreamApiResponseOldStorageBackendException).to be < Stream::StreamApiResponseException }
+  it { expect(Stream::StreamApiResponseJinjaRuntimeException).to be < Stream::StreamApiResponseException }
+  it { expect(Stream::StreamApiResponseBestPracticeException).to be < Stream::StreamApiResponseException }
+  it { expect(Stream::StreamApiResponseDoesNotExistException).to be < Stream::StreamApiResponseException }
+  it { expect(Stream::StreamApiResponseNotAllowedException).to be < Stream::StreamApiResponseException }
+  it { expect(Stream::StreamApiResponseConflictException).to be < Stream::StreamApiResponseException }
   it { expect(Stream::StreamInputData).to be < Stream::Error }
 end


### PR DESCRIPTION
The errors defined are based on
https://getstream.io/activity-feeds/docs/ruby/api_error_responses/?language=ruby and https://github.com/GetStream/stream-python/blob/main/stream/exceptions.py.

This solves #121 .